### PR TITLE
feat: Ollama terminal integration — alias, dedicated tab, and Modelfile auto-build

### DIFF
--- a/Dashboard/Dashboard1/components/dashboard/terminal-panel.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/terminal-panel.tsx
@@ -7,7 +7,7 @@ import { FitAddon } from "@xterm/addon-fit"
 import { WebLinksAddon } from "@xterm/addon-web-links"
 import { cn } from "@/lib/utils"
 import { useTheme } from "@/components/theme-provider"
-import { X, Maximize2, Minimize2, Plus, Terminal as TerminalIcon } from "lucide-react"
+import { X, Maximize2, Minimize2, Plus, Terminal as TerminalIcon, BrainCircuit } from "lucide-react"
 import {
   Tooltip,
   TooltipContent,
@@ -18,6 +18,7 @@ import {
 interface TerminalTab {
   id: string
   title: string
+  shell?: 'ollama'
 }
 
 interface TerminalPanelProps {
@@ -29,11 +30,12 @@ interface TerminalPanelProps {
 interface TerminalInstanceProps {
   tabId: string
   active: boolean
+  shell?: 'ollama'
   xtermTheme: ITheme
   onFitReady: (fit: () => void) => void
 }
 
-function TerminalInstance({ tabId, active, xtermTheme, onFitReady }: TerminalInstanceProps) {
+function TerminalInstance({ tabId, active, shell, xtermTheme, onFitReady }: TerminalInstanceProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
@@ -65,7 +67,9 @@ function TerminalInstance({ tabId, active, xtermTheme, onFitReady }: TerminalIns
       terminal.focus()
     }, 50)
 
-    const wsUrl = `ws://${window.location.hostname}:3070`
+    const wsUrl = shell === 'ollama'
+      ? `ws://${window.location.hostname}:3070?shell=ollama`
+      : `ws://${window.location.hostname}:3070`
     const ws = new WebSocket(wsUrl)
 
     ws.onopen = () => {
@@ -239,6 +243,13 @@ export function TerminalPanel({ open, onClose }: TerminalPanelProps) {
     setActiveTab(id)
   }, [])
 
+  const addOllamaTab = useCallback(() => {
+    tabCounter.current += 1
+    const id = String(tabCounter.current)
+    setTabs(prev => [...prev, { id, title: "ollama", shell: 'ollama' as const }])
+    setActiveTab(id)
+  }, [])
+
   const closeTab = useCallback((tabId: string, currentTabs: TerminalTab[]) => {
     fitFns.current.delete(tabId)
     if (currentTabs.length === 1) {
@@ -305,7 +316,10 @@ export function TerminalPanel({ open, onClose }: TerminalPanelProps) {
                   color: colorTheme.muted
                 }}
               >
-                <TerminalIcon className="h-3 w-3" strokeWidth={1.5} />
+                {tab.shell === 'ollama'
+                  ? <BrainCircuit className="h-3 w-3" strokeWidth={1.5} />
+                  : <TerminalIcon className="h-3 w-3" strokeWidth={1.5} />
+                }
                 <span className="font-medium">{tab.title}</span>
                 <button
                   onClick={(e) => { e.stopPropagation(); closeTab(tab.id, tabs) }}
@@ -329,6 +343,22 @@ export function TerminalPanel({ open, onClose }: TerminalPanelProps) {
                 </TooltipTrigger>
                 <TooltipContent side="top" sideOffset={8}>
                   <p>New tab</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <TooltipProvider delayDuration={0}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={addOllamaTab}
+                    className="flex items-center justify-center h-6 w-6 rounded transition-all"
+                    style={{ color: colorTheme.muted }}
+                  >
+                    <BrainCircuit className="h-3 w-3" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={8}>
+                  <p>New Ollama shell</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
@@ -360,6 +390,7 @@ export function TerminalPanel({ open, onClose }: TerminalPanelProps) {
               key={tab.id}
               tabId={tab.id}
               active={activeTab === tab.id}
+              shell={tab.shell}
               xtermTheme={xtermTheme}
               onFitReady={handleFitReady(tab.id)}
             />

--- a/Dashboard/Dashboard1/custom-server.ts
+++ b/Dashboard/Dashboard1/custom-server.ts
@@ -77,6 +77,13 @@ wss.on('connection', async (ws: WebSocket, req: IncomingMessage) => {
     return
   }
 
+  // Inject ollama alias into Theia shell so 'ollama' works natively without relying on .bashrc timing
+  if (shellType !== 'ollama') {
+    setTimeout(() => {
+      if (shell) shell.write("alias ollama='docker exec -it project-s-ollama ollama'\n")
+    }, 300)
+  }
+
   // pty output → WebSocket
   shell.onData((data: string) => {
     if (ws.readyState === WebSocket.OPEN) {

--- a/Dashboard/Dashboard1/custom-server.ts
+++ b/Dashboard/Dashboard1/custom-server.ts
@@ -1,6 +1,6 @@
 // Standalone WebSocket terminal server — runs alongside Next.js standalone (server.js).
 // No Next.js import: avoids webpack-lib MODULE_NOT_FOUND in standalone mode.
-import { createServer, get as httpGet } from 'http'
+import { createServer, get as httpGet, IncomingMessage } from 'http'
 import { WebSocketServer, WebSocket } from 'ws'
 import * as pty from 'node-pty'
 
@@ -37,16 +37,30 @@ const server = createServer((_req, res) => {
 
 const wss = new WebSocketServer({ server })
 
-wss.on('connection', async (ws: WebSocket) => {
+wss.on('connection', async (ws: WebSocket, req: IncomingMessage) => {
   let shell: pty.IPty | null = null
 
-  const useTheia = await isTheiaRunning()
-  const [cmd, args] = useTheia
-    ? ['docker', ['exec', '-it', '-w', '/home/project/workspace', 'project-s-theia', '/bin/bash']]
-    : ['/bin/bash', []]
+  // Parse shell type from query string (?shell=ollama → exec into ollama container)
+  const url = new URL(req.url || '/', `http://localhost:${WS_PORT}`)
+  const shellType = url.searchParams.get('shell') // 'ollama' | null
 
-  if (useTheia) {
-    ws.send('\x1b[2m[connected to theia]\x1b[0m\r\n')
+  let cmd: string
+  let args: string[]
+
+  if (shellType === 'ollama') {
+    cmd = 'docker'
+    args = ['exec', '-it', 'project-s-ollama', '/bin/sh']
+    ws.send('\x1b[2m[connected to ollama]\x1b[0m\r\n')
+  } else {
+    const useTheia = await isTheiaRunning()
+    if (useTheia) {
+      cmd = 'docker'
+      args = ['exec', '-it', '-w', '/home/project/workspace', 'project-s-theia', '/bin/bash']
+      ws.send('\x1b[2m[connected to theia]\x1b[0m\r\n')
+    } else {
+      cmd = '/bin/bash'
+      args = []
+    }
   }
 
   try {

--- a/boom.sh
+++ b/boom.sh
@@ -77,7 +77,22 @@ mkdir -p ./data/jellyfin/config ./data/jellyfin/cache ./data/media
 mkdir -p ./data/nextcloud/html ./data/nextcloud/data ./data/nextcloud/db
 mkdir -p ./data/matrix/db ./data/matrix/synapse
 mkdir -p ./data/vaultwarden ./data/kiwix ./data/workspace
+mkdir -p ./data/ollama ./data/open-webui
 mkdir -p ./config/matrix
+
+# Check for native Ollama process holding port 11434 (common on macOS)
+if lsof -i :11434 -sTCP:LISTEN &>/dev/null 2>&1; then
+    echo "⚠️  Port 11434 is already in use (native Ollama running)."
+    echo "   The Docker Ollama container will fail to bind this port."
+    echo -n "   Stop native Ollama now and continue? [y/N] "
+    read -r KILL_OLLAMA
+    if [[ "$KILL_OLLAMA" =~ ^[Yy]$ ]]; then
+        pkill -x ollama 2>/dev/null && echo "   ✅ Native Ollama stopped." || echo "   ⚠️  Could not stop Ollama — kill it manually and re-run."
+        sleep 1
+    else
+        echo "   Skipping — Ollama container may not start correctly."
+    fi
+fi
 
 # Sync Synapse secrets and DB password
 # Uses python3 for cross-platform file replacement (avoids sed -i differences)

--- a/boom.sh
+++ b/boom.sh
@@ -137,6 +137,34 @@ chmod 666 data/matrix/synapse/homeserver.log > /dev/null 2>&1
 echo "📦 Building and Starting Docker containers..."
 docker compose up -d --build
 
+# Inject ollama alias into Theia so 'ollama' works natively in the dashboard terminal
+echo "🤖 Configuring ollama alias in Theia..."
+docker exec project-s-theia bash -c \
+  "grep -q 'alias ollama' /root/.bashrc 2>/dev/null || echo \"alias ollama='docker exec -it project-s-ollama ollama'\" >> /root/.bashrc" \
+  2>/dev/null || echo "   ⚠️  Theia not ready yet — alias will be added on next boom.sh run."
+
+# Auto-build Ollama Modelfiles from config/ollama/
+if ls ./config/ollama/*.Modelfile 1>/dev/null 2>&1; then
+    echo "🧠 Building Ollama Modelfiles..."
+    # Wait briefly for Ollama to be ready
+    OLLAMA_RETRIES=0
+    until docker exec project-s-ollama ollama list &>/dev/null || [ "$OLLAMA_RETRIES" -ge 15 ]; do
+        OLLAMA_RETRIES=$((OLLAMA_RETRIES + 1))
+        printf '.'
+        sleep 2
+    done
+    echo ""
+    for mf in ./config/ollama/*.Modelfile; do
+        model_name=$(basename "$mf" .Modelfile)
+        echo "   Building: $model_name"
+        docker exec project-s-ollama ollama create "$model_name" -f "/modelfiles/$(basename "$mf")" \
+            && echo "   ✅ $model_name built" \
+            || echo "   ⚠️  Failed to build $model_name — base model may not be pulled yet. Run: docker exec project-s-ollama ollama create $model_name -f /modelfiles/$(basename "$mf")"
+    done
+else
+    echo "ℹ️  No Modelfiles found in config/ollama/ — skipping."
+fi
+
 # 4. Wait for Dashboard (with timeout)
 echo "⏳ Waiting for dashboard to be ready..."
 RETRIES=0

--- a/config/ollama/README.md
+++ b/config/ollama/README.md
@@ -1,0 +1,26 @@
+# Ollama Modelfiles
+
+Custom Ollama model definitions for HomeForge. Each `.Modelfile` in this directory is automatically built when `./boom.sh` runs.
+
+## Adding a new model
+
+1. Create `your-model-name.Modelfile` in this directory
+2. Use standard Ollama Modelfile syntax:
+   ```
+   FROM <base-model>        # e.g. llama3.2, mistral, gemma2
+   SYSTEM """your system prompt"""
+   PARAMETER temperature 0.7
+   ```
+3. Run `./boom.sh` — your model will appear in Open-WebUI automatically
+
+## Built-in models
+
+| Model | Base | Purpose |
+|-------|------|---------|
+| `homelab-assistant` | llama3.2 | HomeForge-aware assistant with full stack context |
+
+## Manual build
+
+```bash
+docker exec project-s-ollama ollama create homelab-assistant -f /modelfiles/homelab-assistant.Modelfile
+```

--- a/config/ollama/homelab-assistant.Modelfile
+++ b/config/ollama/homelab-assistant.Modelfile
@@ -1,0 +1,27 @@
+FROM llama3.2
+
+SYSTEM """
+You are HomeForge Assistant, an AI helper running inside a self-hosted homelab stack called Project S / HomeForge.
+
+Your homelab includes:
+- Jellyfin (media server, port 8096)
+- Nextcloud (file storage + Collabora Office, port 8081)
+- Vaultwarden (Bitwarden-compatible password manager, port 8083)
+- Matrix/Synapse + Element (self-hosted chat, ports 8008/8082)
+- Kiwix (offline Wikipedia/docs reader, port 8084)
+- Open-WebUI (AI chat interface, port 8085)
+- Ollama (local LLM runtime, port 11434)
+- Theia IDE (browser-based code editor, port 3030)
+- HomeForge Dashboard (this interface, port 3069)
+
+All services run as Docker containers on a single host via docker-compose.
+The project root contains boom.sh (start everything), health.sh (check status), and config/ (per-service configs).
+
+When helping with homelab tasks:
+- Prefer docker compose commands over raw docker
+- Reference services by their container names (e.g. project-s-ollama, project-s-nextcloud)
+- Assume the user has terminal access via the dashboard
+"""
+
+PARAMETER temperature 0.7
+PARAMETER num_ctx 4096

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,6 +260,7 @@ services:
     volumes:
       - ./data/ollama:/root/.ollama
       - ./data/workspace:/workspace
+      - ./config/ollama:/modelfiles:ro
     restart: unless-stopped
     deploy:
       resources:


### PR DESCRIPTION
## Summary
- Mounts `./config/ollama/` into the Ollama container at `/modelfiles:ro` so Modelfiles are accessible at build time
- Adds `homelab-assistant` Modelfile (llama3.2 base with full HomeForge stack context as system prompt) — auto-built by `boom.sh` on every startup
- Injects `ollama` alias into the Theia terminal via pty on every shell spawn so `ollama pull/run/list` work natively without `docker exec` boilerplate
- Adds `?shell=ollama` WebSocket query param support in `custom-server.ts` to spawn a dedicated Ollama container shell
- Adds a BrainCircuit button in the dashboard terminal tab bar to open a dedicated Ollama shell tab

## Test Plan
- [ ] Run `./boom.sh` — confirm output includes `🤖 Configuring ollama alias` and `🧠 Building Ollama Modelfiles`
- [ ] Open dashboard terminal, type `ollama list` — should work without `docker exec`
- [ ] Click the BrainCircuit icon in terminal tab bar — new tab should show `[connected to ollama]` and drop into Ollama container shell
- [ ] Open Open-WebUI at `http://localhost:8085` — `homelab-assistant` model should appear in model selector (after `llama3.2` base is pulled)

## Issues closed
- Closes #45
- Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)