### PR TITLE
feat: nginx reverse proxy, Matrix LAN fix, Collabora fix script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ Dashboard/Dashboard1/node_modules/
 .DS_Store
 Thumbs.db
 dind-data/
+
+# AI tooling (Claude Code superpowers)
+docs/superpowers/
+Dashboard/Dashboard1/docs/superpowers/
+Dashboard/Dashboard1/tsconfig.tsbuildinfo

--- a/Dashboard/Dashboard1/.gitignore
+++ b/Dashboard/Dashboard1/.gitignore
@@ -14,3 +14,4 @@ next.user-config.*
 node_modules
 .next/
 .DS_Store
+tsconfig.tsbuildinfo

--- a/config/matrix/element-config.json
+++ b/config/matrix/element-config.json
@@ -1,7 +1,7 @@
 {
     "default_server_config": {
         "m.homeserver": {
-            "base_url": "http://localhost:8008",
+            "base_url": "http://192.168.178.108:8008",
             "server_name": "localhost"
         },
         "m.identity_server": {

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -1,0 +1,69 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    # Dashboard Proxy
+    server {
+        listen 80;
+        location / {
+            proxy_pass http://dashboard:3069;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+
+    # Jellyfin Proxy
+    server {
+        listen 8096;
+        location / {
+            proxy_pass http://jellyfin:8096;
+            proxy_set_header Host $host;
+            proxy_hide_header X-Frame-Options;
+            proxy_hide_header Content-Security-Policy;
+            add_header Content-Security-Policy "frame-ancestors 'self' http://localhost:3069;" always;
+            add_header X-Frame-Options "ALLOW-FROM http://localhost:3069" always;
+        }
+    }
+
+    # Nextcloud Proxy
+    server {
+        listen 8081;
+        location / {
+            proxy_pass http://nextcloud:80;
+            proxy_set_header Host $host;
+            proxy_hide_header X-Frame-Options;
+            proxy_hide_header Content-Security-Policy;
+            add_header Content-Security-Policy "frame-ancestors 'self' http://localhost:3069;" always;
+            add_header X-Frame-Options "ALLOW-FROM http://localhost:3069" always;
+        }
+    }
+
+    # Matrix/Element Proxy
+    server {
+        listen 8082;
+        location / {
+            proxy_pass http://element:80;
+            proxy_set_header Host $host;
+            proxy_hide_header X-Frame-Options;
+            proxy_hide_header Content-Security-Policy;
+            add_header Content-Security-Policy "frame-ancestors 'self' http://localhost:3069;" always;
+        }
+    }
+
+    # Vaultwarden Proxy
+    server {
+        listen 8083;
+        location / {
+            proxy_pass http://vaultwarden:80;
+            proxy_set_header Host $host;
+            proxy_hide_header X-Frame-Options;
+            proxy_hide_header Content-Security-Policy;
+            add_header Content-Security-Policy "frame-ancestors 'self' http://localhost:3069;" always;
+            add_header X-Frame-Options "ALLOW-FROM http://localhost:3069" always;
+        }
+    }
+}

--- a/fix-office.sh
+++ b/fix-office.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+docker exec -u www-data project-s-nextcloud php /var/www/html/occ config:app:set richdocuments wopi_url --value="http://collabora:9980"
+docker exec -u www-data project-s-nextcloud php /var/www/html/occ config:app:set richdocuments wopi_callback_url --value="http://nextcloud:80"
+docker exec -u www-data project-s-nextcloud php /var/www/html/occ config:app:set richdocuments public_wopi_url --value="http://localhost:9980"
+docker exec -u www-data project-s-nextcloud php /var/www/html/occ config:system:set allow_local_remote_servers --value=true --type=boolean
+docker exec -u www-data project-s-nextcloud php /var/www/html/occ config:system:set trusted_domains 3 --value="collabora"
+echo "---"
+docker exec -u www-data project-s-nextcloud php /var/www/html/occ config:app:get richdocuments wopi_callback_url


### PR DESCRIPTION
## Summary

- **`config/nginx/nginx.conf`** — new nginx reverse proxy config, routes dashboard, Jellyfin, and other services
- **`config/matrix/element-config.json`** — fix Matrix homeserver URL from `localhost` to LAN IP (`192.168.178.108`)
- **`fix-office.sh`** — script to fix Nextcloud/Collabora WOPI URLs and trusted domains
- **`.gitignore`** — ignore `docs/superpowers/` (AI tooling) at repo root
- **`Dashboard/Dashboard1/.gitignore`** — ignore `tsconfig.tsbuildinfo` (TS build artifact)

## Test plan

- [ ] Nginx proxy routes traffic correctly to each service
- [ ] Element connects to Matrix homeserver via LAN IP
- [ ] `fix-office.sh` resolves Collabora WOPI config when run

🤖 Generated with [Claude Code](https://claude.com/claude-code)