### PR TITLE
fix: Nextcloud Office Linux fix — guard HOMEFORGE_LAN_IP + safe .env.example default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,10 @@ COLLABORA_USERNAME=admin
 COLLABORA_PASSWORD=change_me_collabora_password
 
 # --- HomeForge Network -------------------------------------------------------
-# Your machine's LAN IP (optional — allows Nextcloud access from other devices)
+# Your machine's LAN IP — required for Nextcloud Office (Collabora) to work.
+# install.sh auto-detects this, but you can set it manually if needed.
 # Find it with: hostname -I | awk '{print $1}'  (Linux) or ipconfig getifaddr en0 (Mac)
-HOMEFORGE_LAN_IP=
+HOMEFORGE_LAN_IP=localhost
 
 # --- Matrix / Synapse --------------------------------------------------------
 # IMPORTANT: MATRIX_DB_PASSWORD must match the password in config/matrix/homeserver.yaml

--- a/install.sh
+++ b/install.sh
@@ -151,6 +151,15 @@ EOF
 chmod +x ./config/nextcloud/setup-office.sh
 chmod +x ./config/nextcloud/setup-office-post-install.sh
 
+# Verify HOMEFORGE_LAN_IP is set before starting — Collabora's server_name
+# depends on it and will mismatch if empty, causing "Document loading failed".
+FINAL_LAN_IP=$(grep "^HOMEFORGE_LAN_IP=" .env 2>/dev/null | cut -d'=' -f2-)
+if [ -z "$FINAL_LAN_IP" ]; then
+    echo "Error: HOMEFORGE_LAN_IP could not be detected and is not set in .env"
+    echo "Please set it manually: echo 'HOMEFORGE_LAN_IP=<your-machine-ip>' >> .env"
+    exit 1
+fi
+
 # 6. Build and start the containers
 echo "Building and starting containers in the background..."
 if ! docker compose up -d --build; then


### PR DESCRIPTION
## Summary

- **Root cause:** `HOMEFORGE_LAN_IP` was empty in `.env` on Linux, causing Collabora's `server_name` to fall back to a hardcoded Mac IP (`192.168.178.108`). The browser's `Host:` header (`localhost:9980`) didn't match, so Collabora rejected all document connections → *"Document loading failed"*.
- **`install.sh`:** Added a pre-flight guard that aborts with a clear error message if `HOMEFORGE_LAN_IP` is still unset after auto-detection, preventing containers from starting with a broken Collabora configuration.
- **`.env.example`:** Changed `HOMEFORGE_LAN_IP=` (empty) to `HOMEFORGE_LAN_IP=localhost` as a safe neutral default — fresh clones now work out of the box for single-machine use without any manual setup.

## Test plan

- [ ] Fresh clone on Linux — run `install.sh`, verify it auto-detects LAN IP and sets it in `.env`
- [ ] If auto-detect fails, verify `install.sh` exits with a clear error instead of starting broken containers
- [ ] Verify Nextcloud Office opens a document without "Document loading failed"
- [ ] Verify Mac behaviour is unchanged (auto-detect via `ipconfig getifaddr en0` still runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)