### PR TITLE
docs: stop command in README + Log 19 (Nextcloud Office incident)

### DIFF
--- a/Project_S_Logs/19_Nextcloud_Office_HOMEFORGE_LAN_IP_Incident.md
+++ b/Project_S_Logs/19_Nextcloud_Office_HOMEFORGE_LAN_IP_Incident.md
@@ -1,0 +1,122 @@
+# Nextcloud Office — HOMEFORGE_LAN_IP Mismatch Incident
+
+**Date:** 2026-04-03
+**Severity:** HIGH — Nextcloud Office completely broken (Word/Writer/Calc files fail to open)
+**Status:** RESOLVED (PR #60)
+**Related:** Log 17 — Collabora WOPI Postmortem (first Collabora incident)
+
+---
+
+## 1. The Symptom
+
+- Clicking any `.docx`, `.odt`, or `.xlsx` file in Nextcloud opened a blank/loading screen
+- No error message in the browser — the editor simply never loaded
+- `POST /apps/richdocuments/token` returned HTTP 200 (token generation was fine)
+- Collabora container was healthy and running normally
+
+---
+
+## 2. Root Cause
+
+**`HOMEFORGE_LAN_IP=localhost` in `.env` caused a split between where Nextcloud told the browser to find Collabora and where Collabora thought it was.**
+
+### The WOPI Flow (simplified)
+
+```
+User clicks file in Nextcloud
+        │
+Nextcloud generates editor URL using public_wopi_url
+        │   → http://<public_wopi_url>/browser/...?WOPISrc=...
+        │
+Browser loads that URL directly
+        │
+Collabora serves the editor, validates against server_name
+        │
+Collabora fetches file from Nextcloud via wopi_callback_url (Docker-internal)
+```
+
+### What broke
+
+`.env.example` was updated in PR #54 to default `HOMEFORGE_LAN_IP=localhost` (previously empty). When `.env` was regenerated with `cp .env.example .env`, the value became `localhost`.
+
+This caused two misaligned values:
+
+| Setting | Value | Where set |
+|---|---|---|
+| `public_wopi_url` | `http://localhost:9980` | `setup-office.sh` using `${HOMEFORGE_LAN_IP:-localhost}` |
+| Collabora `server_name` | `192.168.178.108:9980` | `docker-compose.yml` with fallback `${HOMEFORGE_LAN_IP:-192.168.178.108}` |
+
+The fallback in `docker-compose.yml` was a **hardcoded Mac IP** (`192.168.178.108`) instead of `localhost`, so when `HOMEFORGE_LAN_IP=localhost`, these two values diverged.
+
+**Result:** The browser was told to load Collabora at `http://localhost:9980`. On any device other than the server itself, `localhost` points to the user's own machine — which has no Collabora. The editor silently failed to load.
+
+### Secondary issue: `fix-office.sh` hardcoded `localhost`
+
+`fix-office.sh` (added in PR #53) always set `public_wopi_url=http://localhost:9980` regardless of `HOMEFORGE_LAN_IP`. If run manually while `HOMEFORGE_LAN_IP` was a real LAN IP, it would re-introduce the mismatch in reverse.
+
+### Third issue: dashboard build failure
+
+`components/metrics/system-chart.tsx` line 1 had a stray `w` character: `w"use client"`. This caused a Turbopack parse error that failed the entire dashboard Docker build, preventing `./boom.sh` from completing.
+
+---
+
+## 3. The Fix (PR #60)
+
+**`docker-compose.yml`** — Changed Collabora `server_name` fallback:
+```yaml
+# Before
+- server_name=${HOMEFORGE_LAN_IP:-192.168.178.108}:9980
+
+# After
+- server_name=${HOMEFORGE_LAN_IP:-localhost}:9980
+```
+
+**`fix-office.sh`** — Reads `HOMEFORGE_LAN_IP` from the live Nextcloud container:
+```bash
+PUBLIC_HOST=$(docker exec project-s-nextcloud printenv HOMEFORGE_LAN_IP 2>/dev/null)
+PUBLIC_HOST="${PUBLIC_HOST:-localhost}"
+```
+
+**`system-chart.tsx`** — Removed stray `w` on line 1.
+
+---
+
+## 4. If This Happens Again
+
+**Symptom:** Clicking a document in Nextcloud results in a loading screen that never resolves.
+
+**Step 1 — Verify the WOPI URLs are consistent:**
+```bash
+docker exec -u www-data project-s-nextcloud php /var/www/html/occ config:app:get richdocuments public_wopi_url
+docker exec project-s-collabora printenv server_name
+```
+Both should use the same hostname (either both `localhost` or both your LAN IP).
+
+**Step 2 — Check `HOMEFORGE_LAN_IP` in `.env`:**
+```bash
+grep HOMEFORGE_LAN_IP .env
+```
+- If accessing HomeForge from **the same machine only**: `localhost` is fine
+- If accessing from **other devices on the network**: must be your machine's LAN IP (e.g. `192.168.178.108`)
+
+Find your LAN IP on Mac:
+```bash
+ipconfig getifaddr en0
+```
+
+**Step 3 — Re-sync WOPI config into the running containers:**
+```bash
+./fix-office.sh
+docker compose up -d collabora   # recreates with new server_name (restart alone is not enough)
+```
+
+> **Important:** `docker compose restart collabora` does NOT pick up `.env` changes. You must use `docker compose up -d collabora` to recreate the container.
+
+---
+
+## 5. Key Rules Going Forward
+
+1. **All hostname fallbacks in `docker-compose.yml` must use `localhost`**, not a hardcoded IP. The only place a real IP belongs is in `.env`.
+2. **`fix-office.sh` must never hardcode `localhost`** — it should always read `HOMEFORGE_LAN_IP` from the live container.
+3. **After changing `.env`, use `docker compose up -d <service>`** (not `restart`) to apply env changes to a running container.
+4. **`cp .env.example .env` resets all your values.** Always set `HOMEFORGE_LAN_IP` to your LAN IP after copying the example.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ chmod +x boom.sh
 
 Cleans up, builds, starts all services, and launches your browser. Use this for day-to-day restarts.
 
+To stop all services:
+
+```bash
+docker compose down
+```
+
 **Option B: The "Install" Script (Linux / First-Time Setup)**
 
 ```bash


### PR DESCRIPTION
Closes #61

**README.md** — Added `docker compose down` stop command directly below the `./boom.sh` block so it's obvious how to stop everything.

**Log 19** — Full write-up of the Nextcloud Office HOMEFORGE_LAN_IP mismatch incident:
- What the symptom looked like
- Exactly why it broke (split between `public_wopi_url` and Collabora `server_name` fallbacks)
- The fix that landed in PR #60
- Step-by-step recovery guide with the exact commands to run if it ever happens again
- Key rules to avoid re-introducing the issue