### PR TITLE
fix: LAN IP auto-detection bypassed when HOMEFORGE_LAN_IP=localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,9 @@ COLLABORA_PASSWORD=change_me_collabora_password
 
 # --- HomeForge Network -------------------------------------------------------
 # Your machine's LAN IP — required for Nextcloud Office (Collabora) to work.
-# install.sh auto-detects this, but you can set it manually if needed.
+# boom.sh and install.sh auto-detect this. Only set manually if auto-detection fails.
 # Find it with: hostname -I | awk '{print $1}'  (Linux) or ipconfig getifaddr en0 (Mac)
-HOMEFORGE_LAN_IP=localhost
+HOMEFORGE_LAN_IP=
 
 # --- Matrix / Synapse --------------------------------------------------------
 # IMPORTANT: MATRIX_DB_PASSWORD must match the password in config/matrix/homeserver.yaml

--- a/boom.sh
+++ b/boom.sh
@@ -25,8 +25,9 @@ if [ ! -f .env ]; then
     fi
 fi
 
-# Auto-detect LAN IP if not set in .env
-if [ -f .env ] && ! grep -q "^HOMEFORGE_LAN_IP=." .env; then
+# Auto-detect LAN IP if not set or set to placeholder 'localhost' in .env
+CURRENT_LAN_IP=$(grep "^HOMEFORGE_LAN_IP=" .env 2>/dev/null | cut -d'=' -f2-)
+if [ -f .env ] && { [ -z "$CURRENT_LAN_IP" ] || [ "$CURRENT_LAN_IP" = "localhost" ]; }; then
     DETECTED_IP=""
     if [[ "$OSTYPE" == "darwin"* ]]; then
         DETECTED_IP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || true)
@@ -36,9 +37,9 @@ if [ -f .env ] && ! grep -q "^HOMEFORGE_LAN_IP=." .env; then
     if [ -n "$DETECTED_IP" ]; then
         echo "Detected LAN IP: $DETECTED_IP"
         python3 -c "
-import sys
+import sys, re
 with open('.env', 'r') as f: content = f.read()
-content = content.replace('HOMEFORGE_LAN_IP=', 'HOMEFORGE_LAN_IP=' + sys.argv[1], 1)
+content = re.sub(r'^HOMEFORGE_LAN_IP=.*', 'HOMEFORGE_LAN_IP=' + sys.argv[1], content, flags=re.MULTILINE)
 with open('.env', 'w') as f: f.write(content)
 " "$DETECTED_IP"
     fi

--- a/install.sh
+++ b/install.sh
@@ -21,8 +21,9 @@ if [ ! -f .env ]; then
     fi
 fi
 
-# Auto-detect LAN IP if not set in .env
-if [ -f .env ] && ! grep -q "^HOMEFORGE_LAN_IP=." .env; then
+# Auto-detect LAN IP if not set or set to placeholder 'localhost' in .env
+CURRENT_LAN_IP=$(grep "^HOMEFORGE_LAN_IP=" .env 2>/dev/null | cut -d'=' -f2-)
+if [ -f .env ] && { [ -z "$CURRENT_LAN_IP" ] || [ "$CURRENT_LAN_IP" = "localhost" ]; }; then
     DETECTED_IP=""
     if [[ "$OSTYPE" == "darwin"* ]]; then
         DETECTED_IP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || true)
@@ -32,9 +33,9 @@ if [ -f .env ] && ! grep -q "^HOMEFORGE_LAN_IP=." .env; then
     if [ -n "$DETECTED_IP" ]; then
         echo "Detected LAN IP: $DETECTED_IP"
         python3 -c "
-import sys
+import sys, re
 with open('.env', 'r') as f: content = f.read()
-content = content.replace('HOMEFORGE_LAN_IP=', 'HOMEFORGE_LAN_IP=' + sys.argv[1], 1)
+content = re.sub(r'^HOMEFORGE_LAN_IP=.*', 'HOMEFORGE_LAN_IP=' + sys.argv[1], content, flags=re.MULTILINE)
 with open('.env', 'w') as f: f.write(content)
 " "$DETECTED_IP"
         echo "Set HOMEFORGE_LAN_IP=$DETECTED_IP in .env"


### PR DESCRIPTION
Closes #64

## What broke

`boom.sh` and `install.sh` check `! grep -q "^HOMEFORGE_LAN_IP=." .env` to decide whether to auto-detect the LAN IP. The `.` matches any character, so `HOMEFORGE_LAN_IP=localhost` passed the check and skipped detection entirely.

Since PR #54 changed `.env.example` to default `HOMEFORGE_LAN_IP=localhost`, every `cp .env.example .env && ./boom.sh` left Collabora configured with `localhost` — breaking Nextcloud Office for all non-localhost browsers.

## Fix

- **`boom.sh` / `install.sh`**: replace the grep check with an explicit empty-or-localhost condition; use `re.sub` instead of `str.replace` so it correctly overwrites the `localhost` placeholder
- **`.env.example`**: revert `HOMEFORGE_LAN_IP` back to empty — auto-detection fires on every fresh clone as originally intended

## Test plan
- [ ] `cp .env.example .env && ./boom.sh` — should print `Detected LAN IP: 192.168.x.x` and set it in `.env`
- [ ] Open a `.docx` in Nextcloud — Collabora editor loads correctly