### PR TITLE
fix: remove harmful cp .env.example .env from README quick start

### DIFF
--- a/Project_S_Logs/19_Nextcloud_Office_HOMEFORGE_LAN_IP_Incident.md
+++ b/Project_S_Logs/19_Nextcloud_Office_HOMEFORGE_LAN_IP_Incident.md
@@ -119,4 +119,4 @@ docker compose up -d collabora   # recreates with new server_name (restart alone
 1. **All hostname fallbacks in `docker-compose.yml` must use `localhost`**, not a hardcoded IP. The only place a real IP belongs is in `.env`.
 2. **`fix-office.sh` must never hardcode `localhost`** — it should always read `HOMEFORGE_LAN_IP` from the live container.
 3. **After changing `.env`, use `docker compose up -d <service>`** (not `restart`) to apply env changes to a running container.
-4. **`cp .env.example .env` resets all your values.** Always set `HOMEFORGE_LAN_IP` to your LAN IP after copying the example.
+4. **Do not run `cp .env.example .env` manually.** Both `boom.sh` and `install.sh` create `.env` automatically on first run and detect your LAN IP. Running the copy command manually resets all your values and bypasses auto-detection.

--- a/README.md
+++ b/README.md
@@ -40,12 +40,11 @@ To start the entire Project S ecosystem with a single command, use the `boom.sh`
 **Option A: The "Boom" Script (Mac / Local)**
 
 ```bash
-cp .env.example .env
 chmod +x boom.sh
 ./boom.sh
 ```
 
-Cleans up, builds, starts all services, and launches your browser. Use this for day-to-day restarts.
+Creates `.env` automatically, detects your LAN IP, builds, starts all services, and launches your browser. Use this for day-to-day restarts.
 
 To stop all services:
 
@@ -56,12 +55,11 @@ docker compose down
 **Option B: The "Install" Script (Linux / First-Time Setup)**
 
 ```bash
-cp .env.example .env
 chmod +x install.sh
 ./install.sh
 ```
 
-Creates data directories, starts all containers, installs Nextcloud Hub apps (Calendar, Contacts, Office, Talk), and configures Nextcloud Office (Collabora). Run this once on a fresh clone.
+Creates `.env` automatically, detects your LAN IP, starts all containers, installs Nextcloud Hub apps (Calendar, Contacts, Office, Talk), and configures Nextcloud Office (Collabora). Run this once on a fresh clone.
 
 > Nextcloud Office is auto-configured on every subsequent container start via `config/nextcloud/setup-office.sh`. No manual steps needed after the first install.
 


### PR DESCRIPTION
Closes #66

## Problem

README told users to run `cp .env.example .env` before `./boom.sh` and `./install.sh`. Both scripts already create `.env` automatically — the manual step was redundant and actively harmful. It overwrites any existing `.env`, resets `HOMEFORGE_LAN_IP` back to `localhost`, and silently breaks Nextcloud Office every time.

## Changes

- **README Option A & B**: removed `cp .env.example .env`; updated descriptions to say the scripts handle `.env` creation and LAN IP detection automatically
- **Log 19 rule 4**: corrected the advice which previously told users to manually copy the example file

## Correct startup commands going forward

**Mac:**
```bash
chmod +x boom.sh
./boom.sh
```

**Linux (first time):**
```bash
chmod +x install.sh
./install.sh
```

That's it. No manual `.env` step needed.