### PR TITLE
fix: warn in setup-office.sh when HOMEFORGE_LAN_IP is localhost

### DIFF
--- a/config/nextcloud/setup-office.sh
+++ b/config/nextcloud/setup-office.sh
@@ -48,7 +48,15 @@ php /var/www/html/occ config:app:set richdocuments wopi_callback_url \
     --value="http://nextcloud:80" || true
 
 # public_wopi_url: Browser → Collabora (the editor iframe URL)
+# IMPORTANT: this value is baked into Nextcloud's Content Security Policy on
+# every page load. If it is 'localhost', the browser will block Collabora from
+# loading on any device that is not the server itself.
 PUBLIC_HOST="${HOMEFORGE_LAN_IP:-localhost}"
+if [ "$PUBLIC_HOST" = "localhost" ]; then
+    echo "WARNING: HOMEFORGE_LAN_IP is not set or is 'localhost'."
+    echo "  Nextcloud Office will only work on the server machine itself."
+    echo "  To fix: set HOMEFORGE_LAN_IP to your LAN IP in .env and recreate containers."
+fi
 php /var/www/html/occ config:app:set richdocuments public_wopi_url \
     --value="http://${PUBLIC_HOST}:9980" || true
 


### PR DESCRIPTION
Closes #68

`setup-office.sh` runs on every Nextcloud start and silently sets `public_wopi_url=http://localhost:9980` when `HOMEFORGE_LAN_IP` is unset or `localhost`. This bakes `localhost` into Nextcloud's CSP, blocking Collabora on any non-localhost browser — with no obvious error message anywhere.

Added an explicit warning logged to stdout when `PUBLIC_HOST` resolves to `localhost`, so the misconfiguration is immediately visible in `docker logs project-s-nextcloud` on startup instead of only surfacing as a cryptic browser CSP violation.

## Test plan
- [ ] Start with `HOMEFORGE_LAN_IP=localhost` → `docker logs project-s-nextcloud` shows the warning
- [ ] Start with correct LAN IP → no warning, documents open normally