### PR TITLE
docs: Kiwix implementation plan — Log 15.1

### DIFF
--- a/Project_S_Logs/15.1_Kiwix_Implementation_Plan.md
+++ b/Project_S_Logs/15.1_Kiwix_Implementation_Plan.md
@@ -1,0 +1,124 @@
+# Kiwix — Implementation Plan & Brainstorm
+
+**Date:** 2026-04-03
+**Related:** Log 15 (Kiwix Integration), Issue #58
+**Branch:** `fix/kiwix-library-sync-and-manager`
+**Status:** Planning
+
+---
+
+## 1. Current State Audit
+
+### What works
+- `./data/kiwix/` volume mount is correct — ZIM files on the host are visible inside the container
+- Dashboard API (`/api/kiwix`) reads ZIM files correctly via `readdir` on `/data/kiwix`
+- ZIM files are present: `wikipedia_en_100_mini_2026-01.zim` confirmed in `data/kiwix/`
+
+### What is broken
+
+| Problem | Root Cause |
+|---|---|
+| New ZIM files invisible until restart | `kiwix-manage` only runs at container startup; no hot-reload |
+| "Manage Library" link is broken | Filebrowser (`kiwix-manager`) crashes — `database.db` is mounted but never pre-created on host |
+| Empty state is a dead-end | UI tells user to restart manually — no button, no action |
+| Kiwix serving wrong port | `main` still has old command (`*.zim` glob on port 80); correct is port 8080 with `library.xml` |
+| `copy_for_library_view.zim` in data dir | Stale/duplicate file that should be removed |
+
+### Filesystem verdict
+- **Read path:** `./data/kiwix` → container `/data` → `kiwix-serve` ✓
+- **Write path:** Browser → Filebrowser (`port 8086`) → `./data/kiwix` on host ✓ (when Filebrowser is fixed)
+- Dashboard container mounts `./data:/data:ro` (read-only) — correct, dashboard only reads
+- The browser's File System Access API is **not needed** — Filebrowser handles uploads entirely
+
+---
+
+## 2. Scope of Work
+
+Five discrete fixes, in dependency order:
+
+### Fix 1 — `docker-compose.yml`: correct Kiwix image, port, and startup command
+The version on `main` uses the old `*.zim` glob command and wrong port. Update to:
+- Image: `ghcr.io/kiwix/kiwix-serve:3.7.0` (pinned, not `latest`)
+- Port: `8084:8080` (container listens on 8080, not 80)
+- Command: use `kiwix-manage` to build `library.xml` at startup, then serve from it
+- Guard: if no `.zim` files found, sleep instead of crash-looping
+
+### Fix 2 — `docker-compose.yml`: fix Filebrowser startup crash
+Filebrowser mounts `./data/filebrowser/database.db:/database.db` but that file doesn't exist on first run → container crashes with a 404.
+
+Fix: pre-create the directory and an empty file in `install.sh` / `boom.sh`:
+```bash
+mkdir -p ./data/filebrowser
+touch ./data/filebrowser/database.db
+```
+Filebrowser initialises its own schema into an empty file on first start.
+
+### Fix 3 — New API route: `/api/kiwix/restart`
+A POST endpoint in the Next.js dashboard that:
+1. Calls the Docker socket (`/var/run/docker.sock`) to restart `project-s-kiwix-reader`
+2. Returns `{ ok: true }` on success, error message on failure
+
+The dashboard container already has `docker.sock` mounted — no new permissions needed.
+
+### Fix 4 — Dashboard UI: tabs + Refresh button
+Replace the current single-panel layout with two tabs:
+
+**Browse tab** (default when ZIM files exist):
+- Iframe pointing to `http://<host>:8084`
+- "Refresh Library" button in the status bar → calls `/api/kiwix/restart` → shows spinner → reloads ZIM list
+
+**Manage tab** (default when library is empty):
+- Embedded iframe pointing to `http://<host>:8086` (Filebrowser)
+- User uploads `.zim` files directly here, then clicks Refresh
+- "Explore Kiwix Library" link to `library.kiwix.org` for downloading ZIM files
+
+Status bar shows ZIM file count when files exist, or "Library empty" with a nudge to the Manage tab.
+
+### Fix 5 — Clean up `copy_for_library_view.zim`
+Delete the stale duplicate from `data/kiwix/`. Not a code change — just a data cleanup step documented here so it isn't forgotten.
+
+---
+
+## 3. File Changes
+
+| File | Change |
+|---|---|
+| `docker-compose.yml` | Fix kiwix image, port, command; fix filebrowser db mount |
+| `boom.sh` | Pre-create `./data/filebrowser/database.db` |
+| `install.sh` | Pre-create `./data/filebrowser/database.db` |
+| `Dashboard/Dashboard1/app/api/kiwix/restart/route.ts` | New POST route — Docker socket restart |
+| `Dashboard/Dashboard1/components/dashboard/kiwix-section.tsx` | Tabs, Refresh button, embedded Filebrowser |
+
+---
+
+## 4. Implementation Order
+
+```
+Fix 1 (docker-compose)
+    → Fix 2 (filebrowser db + scripts)
+        → Fix 3 (restart API)
+            → Fix 4 (dashboard UI)
+                → Fix 5 (data cleanup note)
+```
+
+Each fix is independently testable before moving to the next.
+
+---
+
+## 5. Out of Scope
+
+- Automatic ZIM file detection / file watcher (chosen not to — adds complexity, more failure modes)
+- Kiwix library browsing / download integration beyond the `library.kiwix.org` link
+- Authentication on Filebrowser (homelab, LAN-only)
+- Multiple Kiwix instances or library partitioning
+
+---
+
+## 6. Open Questions Resolved
+
+| Question | Answer |
+|---|---|
+| Browser File System API needed? | No — Filebrowser handles uploads |
+| Hot-reload or manual refresh? | Manual Refresh button via Docker socket restart |
+| Filebrowser DB — create or skip auth? | Pre-create empty file; Filebrowser self-initialises |
+| Pinned or latest image? | Pinned (`3.7.0`) — `latest` caused port/command mismatches |


### PR DESCRIPTION
Refs #58

Adds `Project_S_Logs/15.1_Kiwix_Implementation_Plan.md` — the full brainstorm and implementation plan for the Kiwix fixes.

Covers:
1. Current state audit (what works, what's broken, filesystem verdict)
2. Five discrete fixes in dependency order
3. File change table
4. Implementation order
5. Out of scope decisions
6. Open questions resolved