### PR TITLE
fix(kiwix): library sync, manager crash fix, and dashboard UI overhaul

### DIFF
--- a/Dashboard/Dashboard1/app/api/kiwix/restart/route.ts
+++ b/Dashboard/Dashboard1/app/api/kiwix/restart/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import http from 'http'
+
+export async function POST() {
+  return new Promise<NextResponse>((resolve) => {
+    const req = http.request(
+      {
+        socketPath: '/var/run/docker.sock',
+        path: '/containers/project-s-kiwix-reader/restart',
+        method: 'POST',
+      },
+      (res) => {
+        if (res.statusCode === 204) {
+          resolve(NextResponse.json({ ok: true }))
+        } else {
+          resolve(NextResponse.json({ ok: false, status: res.statusCode }, { status: 500 }))
+        }
+      }
+    )
+    req.on('error', (err) => {
+      resolve(NextResponse.json({ ok: false, error: err.message }, { status: 500 }))
+    })
+    req.end()
+  })
+}

--- a/Dashboard/Dashboard1/components/dashboard/kiwix-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/kiwix-section.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { useTheme } from "@/components/theme-provider"
 import { cn } from "@/lib/utils"
-import { BookOpen, FileText, ExternalLink } from "lucide-react"
+import { BookOpen, FileText, FolderOpen, Search, RefreshCw } from "lucide-react"
 
 interface ZimFile {
   name: string
@@ -23,20 +23,63 @@ function formatSize(bytes: number): string {
 export function KiwixSection({ isWindow }: KiwixSectionProps) {
   const { colorTheme, mode } = useTheme()
   const [serviceUrl, setServiceUrl] = useState("")
+  const [managerUrl, setManagerUrl] = useState("")
   const [zimFiles, setZimFiles] = useState<ZimFile[]>([])
   const [loading, setLoading] = useState(true)
+  const [tab, setTab] = useState<"browse" | "manage">("browse")
+  const [restarting, setRestarting] = useState(false)
 
   useEffect(() => {
     setServiceUrl(`http://${window.location.hostname}:8084`)
+    setManagerUrl(`http://${window.location.hostname}:8086`)
+  }, [])
+
+  const fetchZimFiles = useCallback(() => {
+    return fetch('/api/kiwix')
+      .then(r => r.json())
+      .then(d => {
+        setZimFiles(d.files || [])
+        return d.files || []
+      })
+      .catch(() => {
+        setZimFiles([])
+        return []
+      })
   }, [])
 
   useEffect(() => {
-    fetch('/api/kiwix')
-      .then(r => r.json())
-      .then(d => setZimFiles(d.files || []))
-      .catch(() => setZimFiles([]))
-      .finally(() => setLoading(false))
-  }, [])
+    fetchZimFiles().finally(() => setLoading(false))
+  }, [fetchZimFiles])
+
+  // Default to manage tab when library is empty
+  useEffect(() => {
+    if (!loading && zimFiles.length === 0) setTab("manage")
+  }, [loading, zimFiles.length])
+
+  const handleRefresh = async () => {
+    setRestarting(true)
+    try {
+      await fetch('/api/kiwix/restart', { method: 'POST' })
+      // Poll until file list changes or 30s timeout
+      const start = Date.now()
+      const poll = async (): Promise<void> => {
+        if (Date.now() - start > 30000) return
+        await new Promise(r => setTimeout(r, 2000))
+        const files = await fetchZimFiles()
+        if (files.length !== zimFiles.length) return
+        return poll()
+      }
+      await poll()
+    } finally {
+      setRestarting(false)
+    }
+  }
+
+  const tabStyle = (active: boolean) => ({
+    color: active ? colorTheme.accent : colorTheme.foreground,
+    borderBottomColor: active ? colorTheme.accent : 'transparent',
+    opacity: active ? 1 : 0.4,
+  })
 
   const content = (
     <div
@@ -50,75 +93,114 @@ export function KiwixSection({ isWindow }: KiwixSectionProps) {
         backdropFilter: 'blur(24px)',
       } : undefined}
     >
-      {/* ZIM file status bar */}
+      {/* Status bar */}
       <div
-        className="shrink-0 flex items-center gap-3 px-4 py-2 border-b text-xs"
+        className="shrink-0 flex items-center justify-between gap-3 px-4 py-2 border-b text-xs"
         style={{ borderColor: colorTheme.border }}
       >
-        <BookOpen className="h-3.5 w-3.5 shrink-0" style={{ color: colorTheme.accent }} />
-        {loading ? (
-          <span className="opacity-40" style={{ color: colorTheme.foreground }}>Scanning library…</span>
-        ) : zimFiles.length > 0 ? (
-          <div className="flex items-center gap-3 flex-wrap">
-            <span className="font-semibold" style={{ color: colorTheme.foreground }}>
-              {zimFiles.length} ZIM {zimFiles.length === 1 ? 'file' : 'files'} available
-            </span>
-            {zimFiles.map(f => (
-              <span key={f.name} className="flex items-center gap-1 opacity-50" style={{ color: colorTheme.foreground }}>
-                <FileText className="h-3 w-3" />
-                {f.name.replace('.zim', '')}
-                <span className="opacity-60">({formatSize(f.sizeBytes)})</span>
+        <div className="flex items-center gap-3 overflow-hidden">
+          <BookOpen className="h-3.5 w-3.5 shrink-0" style={{ color: colorTheme.accent }} />
+          {loading ? (
+            <span className="opacity-40" style={{ color: colorTheme.foreground }}>Scanning library…</span>
+          ) : zimFiles.length > 0 ? (
+            <div className="flex items-center gap-3 flex-wrap overflow-hidden">
+              <span className="font-semibold whitespace-nowrap" style={{ color: colorTheme.foreground }}>
+                {zimFiles.length} ZIM {zimFiles.length === 1 ? 'file' : 'files'}
               </span>
-            ))}
-          </div>
-        ) : (
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className="opacity-50" style={{ color: colorTheme.foreground }}>No ZIM files found in</span>
-            <code className="px-1.5 py-0.5 rounded text-[10px] font-mono opacity-60"
-              style={{ backgroundColor: `${colorTheme.accent}20`, color: colorTheme.accent }}>
-              ./data/kiwix/
-            </code>
-            <a
-              href="https://library.kiwix.org"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-1 font-medium transition-opacity hover:opacity-80"
-              style={{ color: colorTheme.accent }}
-            >
-              Download ZIM files
-              <ExternalLink className="h-3 w-3" />
-            </a>
-          </div>
-        )}
+              {zimFiles.slice(0, 2).map(f => (
+                <span key={f.name} className="flex items-center gap-1 opacity-50 overflow-hidden whitespace-nowrap" style={{ color: colorTheme.foreground }}>
+                  <FileText className="h-3 w-3" />
+                  {f.name.replace('.zim', '').slice(0, 20)} · {formatSize(f.sizeBytes)}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <span className="opacity-50" style={{ color: colorTheme.foreground }}>Library empty — upload a ZIM file to get started</span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          <a
+            href="https://library.kiwix.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 px-2 py-1 rounded-md transition-all hover:bg-white/10"
+            style={{ color: colorTheme.accent }}
+          >
+            <Search className="h-3 w-3" />
+            Find ZIMs
+          </a>
+          <button
+            onClick={handleRefresh}
+            disabled={restarting}
+            className="flex items-center gap-1 px-2 py-1 rounded-md transition-all font-medium hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
+            style={{ backgroundColor: `${colorTheme.accent}20`, color: colorTheme.accent }}
+          >
+            <RefreshCw className={cn("h-3 w-3", restarting && "animate-spin")} />
+            {restarting ? 'Restarting…' : 'Refresh Library'}
+          </button>
+        </div>
       </div>
 
-      {/* Kiwix iframe */}
-      <div className="flex-1 relative">
-        {serviceUrl && zimFiles.length > 0 && (
+      {/* Tabs */}
+      <div
+        className="shrink-0 flex border-b text-xs"
+        style={{ borderColor: colorTheme.border }}
+      >
+        {(['browse', 'manage'] as const).map(t => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className="px-4 py-2 font-medium border-b-2 transition-all capitalize"
+            style={tabStyle(tab === t)}
+          >
+            {t === 'browse'
+              ? <span className="flex items-center gap-1.5"><BookOpen className="h-3 w-3" />Browse</span>
+              : <span className="flex items-center gap-1.5"><FolderOpen className="h-3 w-3" />Manage</span>
+            }
+          </button>
+        ))}
+      </div>
+
+      {/* Panel */}
+      <div className="flex-1 relative overflow-hidden">
+        {tab === 'browse' && (
+          <>
+            {serviceUrl && zimFiles.length > 0 && (
+              <iframe
+                src={serviceUrl}
+                className="w-full h-full border-0"
+                title="Kiwix Offline Knowledge Base"
+                allowFullScreen
+              />
+            )}
+            {!loading && zimFiles.length === 0 && (
+              <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 p-8">
+                <BookOpen className="h-12 w-12 opacity-10" style={{ color: colorTheme.foreground }} />
+                <div className="text-center space-y-2">
+                  <p className="text-sm font-semibold" style={{ color: colorTheme.foreground }}>
+                    No ZIM files yet
+                  </p>
+                  <p className="text-xs opacity-40 max-w-xs" style={{ color: colorTheme.foreground }}>
+                    Switch to the <strong>Manage</strong> tab to upload files, or download them from{' '}
+                    <a href="https://library.kiwix.org" target="_blank" rel="noopener noreferrer"
+                      className="underline" style={{ color: colorTheme.accent }}>
+                      library.kiwix.org
+                    </a>
+                  </p>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        {tab === 'manage' && managerUrl && (
           <iframe
-            src={serviceUrl}
+            src={managerUrl}
             className="w-full h-full border-0"
-            title="Kiwix Offline Knowledge Base"
+            title="Kiwix Library Manager"
             allowFullScreen
           />
-        )}
-        {!loading && zimFiles.length === 0 && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 p-8">
-            <BookOpen className="h-12 w-12 opacity-10" style={{ color: colorTheme.foreground }} />
-            <div className="text-center space-y-2">
-              <p className="text-sm font-semibold" style={{ color: colorTheme.foreground }}>
-                Your offline library is empty
-              </p>
-              <p className="text-xs opacity-40 max-w-xs" style={{ color: colorTheme.foreground }}>
-                Download <code>.zim</code> files from{' '}
-                <a href="https://library.kiwix.org" target="_blank" rel="noopener noreferrer"
-                  className="underline" style={{ color: colorTheme.accent }}>
-                  library.kiwix.org
-                </a>{' '}
-                and place them in <code className="font-mono">./data/kiwix/</code> then restart the Kiwix container.
-              </p>
-            </div>
-          </div>
         )}
       </div>
     </div>

--- a/boom.sh
+++ b/boom.sh
@@ -78,6 +78,7 @@ mkdir -p ./data/nextcloud/html ./data/nextcloud/data ./data/nextcloud/db
 mkdir -p ./data/matrix/db ./data/matrix/synapse
 mkdir -p ./data/vaultwarden ./data/kiwix ./data/workspace
 mkdir -p ./data/ollama ./data/open-webui
+mkdir -p ./data/filebrowser && touch ./data/filebrowser/database.db
 mkdir -p ./config/matrix
 
 # Check for native Ollama process holding port 11434 (common on macOS)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,8 +276,27 @@ services:
     image: ghcr.io/kiwix/kiwix-serve:3.7.0
     container_name: project-s-kiwix-reader
     ports:
-      - '8084:80'
+      - '8084:8080'
     volumes:
       - ./data/kiwix:/data
-    command: sh -c "kiwix-serve --port=80 *.zim || (echo 'No ZIM files found. Please add .zim files to ./data/kiwix' && sleep infinity)"
+    entrypoint: ["sh", "-c"]
+    command: >
+      "rm -f /data/library.xml &&
+      if ls /data/*.zim >/dev/null 2>&1; then
+        kiwix-manage /data/library.xml add /data/*.zim &&
+        kiwix-serve --port=8080 --library /data/library.xml;
+      else
+        echo 'No ZIM files found. Add .zim files to ./data/kiwix and click Refresh.' && sleep infinity;
+      fi"
+    restart: unless-stopped
+
+  kiwix-manager:
+    image: filebrowser/filebrowser:latest
+    container_name: project-s-kiwix-manager
+    user: "${UID:-1000}:${GID:-1000}"
+    ports:
+      - '8086:80'
+    volumes:
+      - ./data/kiwix:/srv
+      - ./data/filebrowser/database.db:/database.db
     restart: unless-stopped

--- a/install.sh
+++ b/install.sh
@@ -68,6 +68,7 @@ mkdir -p ./data/matrix/db ./data/matrix/synapse
 mkdir -p ./data/vaultwarden
 mkdir -p ./data/kiwix
 mkdir -p ./data/workspace
+mkdir -p ./data/filebrowser && touch ./data/filebrowser/database.db
 mkdir -p ./config/matrix
 
 # Ensure Nextcloud directories have correct permissions (UID 33 is www-data in the container)


### PR DESCRIPTION
Closes #58

## What changed

**Fix 1 — `docker-compose.yml`**
- Pinned `kiwix-serve:3.7.0`, fixed port `80→8080`
- Replaced the old `*.zim` glob command with `kiwix-manage` to properly build `library.xml` at startup
- Added `kiwix-manager` (Filebrowser) service on port 8086

**Fix 2 — `boom.sh` + `install.sh`**
- Pre-create `./data/filebrowser/database.db` before containers start
- Filebrowser was crashing with a 404 because Docker was creating this as a directory instead of a file

**Fix 3 — `app/api/kiwix/restart/route.ts`** (new)
- `POST /api/kiwix/restart` calls the Docker socket to restart `project-s-kiwix-reader`
- Raw Node `http` with `socketPath` — no new dependencies

**Fix 4 — `kiwix-section.tsx`**
- Browse / Manage tab system
- Refresh button with spinner + disabled state during restart
- Polls `/api/kiwix` after restart until file list changes
- Manage tab embeds Filebrowser directly (no more broken external link)
- Auto-switches to Manage tab when library is empty

**Fix 5 — data cleanup**
- Deleted `copy_for_library_view.zim` (duplicate file polluting the index)

## Test plan
- [ ] `./boom.sh` — `./data/filebrowser/database.db` is created as a file, Filebrowser starts cleanly
- [ ] Drop a `.zim` file into `./data/kiwix/`, click Refresh — spinner shows, container restarts, Browse tab loads
- [ ] Empty library → auto-switches to Manage tab with embedded Filebrowser
- [ ] Upload a ZIM via Filebrowser, click Refresh — Browse tab shows new file