### PR TITLE
fix(compose): pin filebrowser image and add --noauth flag to kiwix-manager [Phase 1 of #72]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,7 +291,7 @@ services:
     restart: unless-stopped
 
   kiwix-manager:
-    image: filebrowser/filebrowser:latest
+    image: filebrowser/filebrowser:v2.31.2
     container_name: project-s-kiwix-manager
     user: "${UID:-1000}:${GID:-1000}"
     ports:
@@ -299,4 +299,5 @@ services:
     volumes:
       - ./data/kiwix:/srv
       - ./data/filebrowser/database.db:/database.db
+    command: ["--database", "/database.db", "--noauth", "--root", "/srv"]
     restart: unless-stopped


### PR DESCRIPTION
## Summary

Completes Phase 1 of #72. Two surgical changes to the `kiwix-manager` service in `docker-compose.yml`:

- **Image pinned** — `filebrowser/filebrowser:latest` → `filebrowser/filebrowser:v2.31.2` for reproducible builds
- **`command` added** — `["--database", "/database.db", "--noauth", "--root", "/srv"]` so the embedded Filebrowser iframe in the dashboard loads without a login wall

Closes #74.

## What was broken
Without `--noauth`, Filebrowser generates a random admin password on first boot → the dashboard iframe hits a login wall and never loads. Without `--database`, Filebrowser ignores the mounted DB file.

## Acceptance criteria
- [x] `filebrowser/filebrowser:latest` → pinned `v2.31.2`
- [x] `command` added with `--noauth`, `--database /database.db`, `--root /srv`
- [ ] `docker compose up -d` / `curl localhost:8086` — manual verification (needs DB file from Phase 2)

## Notes
- Can be squash-merged independently of Phase 2
- Phase 2 (`fix/kiwix-phase-2-scripts`) will pre-create `./data/filebrowser/database.db` via `boom.sh`/`install.sh` — until then the manager will error on first run, which is expected

## Files changed
- `docker-compose.yml` — `kiwix-manager` service only (2 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)