### PR TITLE
fix: replace curl healthchecks with native tools for theia and ollama

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,7 @@ services:
         limits:
           memory: 2g
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/"]
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:3000/',r=>{process.exit(r.statusCode<400?0:1)}).on('error',()=>process.exit(1))"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -266,7 +266,7 @@ services:
         limits:
           memory: 4g
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/"]
+      test: ["CMD", "ollama", "list"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

Closes #85

Both `project-s-theia` and `project-s-ollama` were permanently `unhealthy` (96+ failures) because their healthchecks called `curl`, which is not installed in either image.

## Changes

| Container | Before | After |
|-----------|--------|-------|
| `project-s-theia` | `curl -f http://localhost:3000/` | `node -e "require('http').get(...)"` |
| `project-s-ollama` | `curl -f http://localhost:11434/` | `ollama list` |

**Theia** — uses `node` (already in image) to make an HTTP request  
**Ollama** — uses the `ollama` CLI (built into the image) as a daemon health probe

## Verified

Both containers confirmed `healthy` locally after applying the fix.

## Test plan
- [ ] Confirm `project-s-theia` shows `healthy` after deploy
- [ ] Confirm `project-s-ollama` shows `healthy` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)