### PR TITLE
fix: add .dockerignore to prevent Docker build failures after local installs

### DIFF
--- a/Dashboard/Dashboard1/.dockerignore
+++ b/Dashboard/Dashboard1/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.git
+*.md


### PR DESCRIPTION
## Summary

Adds a `.dockerignore` file to `Dashboard/Dashboard1/` to prevent the host `node_modules` directory from being sent into the Docker build context.

## Problem

Without `.dockerignore`, `COPY . .` in the Dockerfile copies the host `node_modules` into the builder stage, conflicting with the `node_modules` already installed by the `deps` stage. This causes build failures like:

```
failed to solve: cannot replace to directory [...]/node_modules/@hookform/resolvers with file
```

This was triggered after running `npm install` locally (as part of the lodash vulnerability fix in #84).

## Changes

- `Dashboard/Dashboard1/.dockerignore` — excludes `node_modules`, `.next`, `.git`, `*.md`

## Test plan
- [ ] Confirm `./boom.sh` completes successfully after a local `npm install`
- [ ] Confirm Docker build does not copy host `node_modules` into image

🤖 Generated with [Claude Code](https://claude.com/claude-code)