### PR TITLE
fix: terminal integration and unity (closes #89)

### DIFF
--- a/Dashboard/Dashboard1/app/page.tsx
+++ b/Dashboard/Dashboard1/app/page.tsx
@@ -14,6 +14,7 @@ export default function HomePage() {
   const [scrollProgress, setScrollProgress] = useState(0)
   const [mounted, setMounted] = useState(false)
   const [terminalOpen, setTerminalOpen] = useState(false)
+  const [execTarget, setExecTarget] = useState<string | undefined>()
   const [currentSection, setCurrentSection] = useState("home")
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -122,7 +123,7 @@ export default function HomePage() {
                   transition: "opacity 0.1s ease-out, transform 0.1s ease-out",
                 }}
               >
-                <DashboardSection />
+                <DashboardSection onExecContainer={(name) => { setExecTarget(name); setTerminalOpen(true) }} />
               </div>
             </>
           ) : (
@@ -132,7 +133,12 @@ export default function HomePage() {
       </main>
 
       {/* Terminal Panel */}
-      <TerminalPanel open={terminalOpen} onClose={() => setTerminalOpen(false)} />
+      <TerminalPanel
+        open={terminalOpen}
+        onClose={() => setTerminalOpen(false)}
+        execTarget={execTarget}
+        onExecConsumed={() => setExecTarget(undefined)}
+      />
 
       {/* Global Styles for Aurora Animation */}
       <style jsx global>{`

--- a/Dashboard/Dashboard1/components/dashboard/dashboard-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/dashboard-section.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, useRef } from "react"
 import { useTheme } from "@/components/theme-provider"
 import { cn } from "@/lib/utils"
-import { Cpu, MemoryStick, HardDrive, Wifi, Activity, Server, AlertTriangle, Clock, Database } from "lucide-react"
+import { Cpu, MemoryStick, HardDrive, Wifi, Activity, Server, AlertTriangle, Clock, Database, Terminal } from "lucide-react"
 import {
   AreaChart,
   Area,
@@ -159,7 +159,11 @@ function MemoryGauge({ value }: { value: number }) {
 
 const STORAGE_COLORS = ['#d4e157', '#22d3ee', '#a855f7', '#fb923c', '#ec4899'];
 
-export function DashboardSection() {
+interface DashboardSectionProps {
+  onExecContainer?: (containerName: string) => void
+}
+
+export function DashboardSection({ onExecContainer }: DashboardSectionProps) {
   const { colorTheme } = useTheme()
   const [stats, setStats] = useState<StatsData | null>(null)
   const [cpuHistory, setCpuHistory] = useState<HistoryPoint[]>([])
@@ -403,7 +407,7 @@ export function DashboardSection() {
           <h3 className="text-lg font-semibold mb-4" style={{ color: colorTheme.foreground }}>Active Infrastructure</h3>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {(stats?.containers || []).map((service) => (
-              <div 
+              <div
                 key={service.name}
                 className="flex items-center justify-between p-4 rounded-xl border border-white/[0.06] bg-white/[0.02] backdrop-blur-xl transition-all"
               >
@@ -412,6 +416,16 @@ export function DashboardSection() {
                   <p className="text-[10px] text-foreground/50 uppercase tracking-tighter">Docker Container</p>
                 </div>
                 <div className="flex items-center gap-2">
+                  {onExecContainer && (
+                    <button
+                      onClick={() => onExecContainer(`project-s-${service.name}`)}
+                      className="flex items-center justify-center h-6 w-6 rounded transition-all opacity-30 hover:opacity-100"
+                      style={{ color: colorTheme.foreground }}
+                      title={`Open terminal in ${service.name}`}
+                    >
+                      <Terminal className="h-3.5 w-3.5" />
+                    </button>
+                  )}
                   <span className="text-[10px] px-2 py-0.5 rounded font-bold uppercase bg-green-500/20 text-green-500">
                     Running
                   </span>

--- a/Dashboard/Dashboard1/components/dashboard/terminal-panel.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/terminal-panel.tsx
@@ -177,11 +177,8 @@ export function TerminalPanel({ open, onClose, execTarget, onExecConsumed }: Ter
   const resizeRef = useRef<HTMLDivElement>(null)
   const tabCounter = useRef(1)
   const fitFns = useRef<Map<string, () => void>>(new Map())
-
-  // Fix #4: keep panel in DOM after first open so sessions survive close/reopen
+  // Fix #4: track whether the panel has ever been opened
   const hasEverOpened = useRef(false)
-  if (open) hasEverOpened.current = true
-  if (!hasEverOpened.current) return null
 
   const xtermTheme = useMemo<ITheme>(() => ({
     background:    mode === 'dark' ? '#0a0a0a' : '#f5f5f5',
@@ -301,6 +298,10 @@ export function TerminalPanel({ open, onClose, execTarget, onExecConsumed }: Ter
       return remaining
     })
   }, [onClose])
+
+  // Fix #4: guard AFTER all hooks — Rules of Hooks satisfied
+  if (open) hasEverOpened.current = true
+  if (!hasEverOpened.current) return null
 
   const panelHeight = isMaximized ? "100vh" : `${height}px`
 

--- a/Dashboard/Dashboard1/components/dashboard/terminal-panel.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/terminal-panel.tsx
@@ -7,7 +7,7 @@ import { FitAddon } from "@xterm/addon-fit"
 import { WebLinksAddon } from "@xterm/addon-web-links"
 import { cn } from "@/lib/utils"
 import { useTheme } from "@/components/theme-provider"
-import { X, Maximize2, Minimize2, Plus, Terminal as TerminalIcon, BrainCircuit } from "lucide-react"
+import { X, Maximize2, Minimize2, Plus, Terminal as TerminalIcon, BrainCircuit, Container } from "lucide-react"
 import {
   Tooltip,
   TooltipContent,
@@ -18,30 +18,33 @@ import {
 interface TerminalTab {
   id: string
   title: string
-  shell?: 'ollama'
+  shell?: 'ollama' | 'container'
+  containerName?: string
 }
 
 interface TerminalPanelProps {
   open: boolean
   onClose: () => void
+  execTarget?: string         // full container name to exec into (e.g. 'project-s-jellyfin')
+  onExecConsumed?: () => void // called after execTarget has been consumed
 }
 
-// Per-tab terminal instance — mounts once, stays alive until tab is closed
 interface TerminalInstanceProps {
   tabId: string
   active: boolean
-  shell?: 'ollama'
+  shell?: 'ollama' | 'container'
+  containerName?: string
   xtermTheme: ITheme
   onFitReady: (fit: () => void) => void
+  onTitleChange?: (title: string) => void
 }
 
-function TerminalInstance({ tabId, active, shell, xtermTheme, onFitReady }: TerminalInstanceProps) {
+function TerminalInstance({ tabId, active, shell, containerName, xtermTheme, onFitReady, onTitleChange }: TerminalInstanceProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const termRef = useRef<Terminal | null>(null)
   const fitRef = useRef<FitAddon | null>(null)
   const wsRef = useRef<WebSocket | null>(null)
 
-  // Initialize terminal + WebSocket on mount
   useEffect(() => {
     const container = containerRef.current
     if (!container) return
@@ -61,15 +64,27 @@ function TerminalInstance({ tabId, active, shell, xtermTheme, onFitReady }: Term
     terminal.loadAddon(new WebLinksAddon())
     terminal.open(container)
 
-    // Fit after paint so container has dimensions
     const fitTimer = setTimeout(() => {
       fitAddon.fit()
       terminal.focus()
     }, 50)
 
-    const wsUrl = shell === 'ollama'
-      ? `ws://${window.location.hostname}:3070?shell=ollama`
-      : `ws://${window.location.hostname}:3070`
+    // Fix #6: dynamic tab title via OSC escape sequences from the pty
+    terminal.onTitleChange((title: string) => {
+      if (title) onTitleChange?.(title)
+    })
+
+    // Fix #1: detect ws vs wss based on page protocol
+    const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
+    let wsUrl: string
+    if (shell === 'container' && containerName) {
+      wsUrl = `${proto}://${window.location.hostname}:3070?shell=container&container=${encodeURIComponent(containerName)}`
+    } else if (shell === 'ollama') {
+      wsUrl = `${proto}://${window.location.hostname}:3070?shell=ollama`
+    } else {
+      wsUrl = `${proto}://${window.location.hostname}:3070`
+    }
+
     const ws = new WebSocket(wsUrl)
 
     ws.onopen = () => {
@@ -101,7 +116,6 @@ function TerminalInstance({ tabId, active, shell, xtermTheme, onFitReady }: Term
     fitRef.current = fitAddon
     wsRef.current = ws
 
-    // Expose fit function to parent for resize handling
     onFitReady(() => {
       if (fitRef.current && wsRef.current) {
         fitRef.current.fit()
@@ -120,7 +134,6 @@ function TerminalInstance({ tabId, active, shell, xtermTheme, onFitReady }: Term
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // When tab becomes active, re-fit and focus
   useEffect(() => {
     if (!active) return
     const timer = setTimeout(() => {
@@ -136,7 +149,6 @@ function TerminalInstance({ tabId, active, shell, xtermTheme, onFitReady }: Term
     return () => clearTimeout(timer)
   }, [active])
 
-  // Update xterm theme when dashboard theme changes
   useEffect(() => {
     if (termRef.current) {
       termRef.current.options.theme = xtermTheme
@@ -155,7 +167,7 @@ function TerminalInstance({ tabId, active, shell, xtermTheme, onFitReady }: Term
   )
 }
 
-export function TerminalPanel({ open, onClose }: TerminalPanelProps) {
+export function TerminalPanel({ open, onClose, execTarget, onExecConsumed }: TerminalPanelProps) {
   const { colorTheme, mode } = useTheme()
   const [tabs, setTabs] = useState<TerminalTab[]>([{ id: "1", title: "bash" }])
   const [activeTab, setActiveTab] = useState("1")
@@ -164,8 +176,12 @@ export function TerminalPanel({ open, onClose }: TerminalPanelProps) {
 
   const resizeRef = useRef<HTMLDivElement>(null)
   const tabCounter = useRef(1)
-  // Stores fit+resize functions per tab so parent can trigger on panel resize
   const fitFns = useRef<Map<string, () => void>>(new Map())
+
+  // Fix #4: keep panel in DOM after first open so sessions survive close/reopen
+  const hasEverOpened = useRef(false)
+  if (open) hasEverOpened.current = true
+  if (!hasEverOpened.current) return null
 
   const xtermTheme = useMemo<ITheme>(() => ({
     background:    mode === 'dark' ? '#0a0a0a' : '#f5f5f5',
@@ -194,6 +210,29 @@ export function TerminalPanel({ open, onClose }: TerminalPanelProps) {
   const handleFitReady = useCallback((tabId: string) => (fn: () => void) => {
     fitFns.current.set(tabId, fn)
   }, [])
+
+  // Fix #6: dynamic tab title updates from OSC sequences
+  const handleTitleChange = useCallback((tabId: string) => (title: string) => {
+    setTabs(prev => prev.map(t => t.id === tabId ? { ...t, title } : t))
+  }, [])
+
+  // Fix #4: re-fit when panel slides back into view
+  useEffect(() => {
+    if (!open) return
+    const timer = setTimeout(() => fitFns.current.get(activeTab)?.(), 100)
+    return () => clearTimeout(timer)
+  }, [open, activeTab])
+
+  // Fix #5: open a new exec tab when a container tile triggers it
+  useEffect(() => {
+    if (!execTarget) return
+    tabCounter.current += 1
+    const id = String(tabCounter.current)
+    const shortName = execTarget.replace('project-s-', '')
+    setTabs(prev => [...prev, { id, title: shortName, shell: 'container', containerName: execTarget }])
+    setActiveTab(id)
+    onExecConsumed?.()
+  }, [execTarget, onExecConsumed])
 
   // Resize handle drag
   useEffect(() => {
@@ -230,7 +269,6 @@ export function TerminalPanel({ open, onClose }: TerminalPanelProps) {
     return () => resizeEl.removeEventListener("mousedown", onMouseDown)
   }, [height, activeTab])
 
-  // Re-fit on maximize toggle
   useEffect(() => {
     const timer = setTimeout(() => fitFns.current.get(activeTab)?.(), 100)
     return () => clearTimeout(timer)
@@ -250,31 +288,30 @@ export function TerminalPanel({ open, onClose }: TerminalPanelProps) {
     setActiveTab(id)
   }, [])
 
-  const closeTab = useCallback((tabId: string, currentTabs: TerminalTab[]) => {
+  // Fix #3: stale closure fix — use functional state updater, no more passing tabs as param
+  const closeTab = useCallback((tabId: string) => {
     fitFns.current.delete(tabId)
-    if (currentTabs.length === 1) {
-      onClose()
-      return
-    }
-    const remaining = currentTabs.filter(t => t.id !== tabId)
-    setTabs(remaining)
-    setActiveTab(prev => prev === tabId ? remaining[0].id : prev)
+    setTabs(prev => {
+      if (prev.length === 1) {
+        onClose()
+        return prev
+      }
+      const remaining = prev.filter(t => t.id !== tabId)
+      setActiveTab(a => a === tabId ? remaining[0].id : a)
+      return remaining
+    })
   }, [onClose])
-
-  if (!open) return null
 
   const panelHeight = isMaximized ? "100vh" : `${height}px`
 
   return (
+    // Fix #4: use CSS transform to hide instead of unmounting — sessions stay alive
     <div
-      className={cn(
-        "fixed bottom-0 left-0 right-0 z-[60] flex flex-col",
-        "transition-transform duration-300 ease-out",
-        open ? "translate-y-0" : "translate-y-full"
-      )}
+      className="fixed bottom-0 left-0 right-0 z-[60] flex flex-col transition-transform duration-300 ease-out"
       style={{
         height: panelHeight,
         marginLeft: isMaximized ? 0 : "72px",
+        transform: open ? 'translateY(0)' : 'translateY(100%)',
       }}
     >
       {/* Resize Handle */}
@@ -318,11 +355,13 @@ export function TerminalPanel({ open, onClose }: TerminalPanelProps) {
               >
                 {tab.shell === 'ollama'
                   ? <BrainCircuit className="h-3 w-3" strokeWidth={1.5} />
+                  : tab.shell === 'container'
+                  ? <Container className="h-3 w-3" strokeWidth={1.5} />
                   : <TerminalIcon className="h-3 w-3" strokeWidth={1.5} />
                 }
                 <span className="font-medium">{tab.title}</span>
                 <button
-                  onClick={(e) => { e.stopPropagation(); closeTab(tab.id, tabs) }}
+                  onClick={(e) => { e.stopPropagation(); closeTab(tab.id) }}
                   className="ml-1 opacity-0 group-hover:opacity-100 transition-all"
                   style={{ color: `${colorTheme.muted}80` }}
                 >
@@ -342,7 +381,7 @@ export function TerminalPanel({ open, onClose }: TerminalPanelProps) {
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="top" sideOffset={8}>
-                  <p>New tab</p>
+                  <p>New bash tab</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
@@ -391,8 +430,10 @@ export function TerminalPanel({ open, onClose }: TerminalPanelProps) {
               tabId={tab.id}
               active={activeTab === tab.id}
               shell={tab.shell}
+              containerName={tab.containerName}
               xtermTheme={xtermTheme}
               onFitReady={handleFitReady(tab.id)}
+              onTitleChange={handleTitleChange(tab.id)}
             />
           ))}
         </div>

--- a/Dashboard/Dashboard1/custom-server.ts
+++ b/Dashboard/Dashboard1/custom-server.ts
@@ -30,6 +30,29 @@ function isTheiaRunning(): Promise<boolean> {
   })
 }
 
+/** Check if a named container is running via Docker socket. */
+function isContainerRunning(name: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const req = httpGet({
+      socketPath: '/var/run/docker.sock',
+      path: `/containers/${name}/json`,
+    }, (res) => {
+      let data = ''
+      res.on('data', (chunk) => { data += chunk })
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data)
+          resolve(json?.State?.Running === true)
+        } catch {
+          resolve(false)
+        }
+      })
+    })
+    req.on('error', () => resolve(false))
+    req.setTimeout(2000, () => { req.destroy(); resolve(false) })
+  })
+}
+
 const server = createServer((_req, res) => {
   res.writeHead(200)
   res.end('Project S Terminal WS Server\n')
@@ -40,9 +63,9 @@ const wss = new WebSocketServer({ server })
 wss.on('connection', async (ws: WebSocket, req: IncomingMessage) => {
   let shell: pty.IPty | null = null
 
-  // Parse shell type from query string (?shell=ollama → exec into ollama container)
   const url = new URL(req.url || '/', `http://localhost:${WS_PORT}`)
-  const shellType = url.searchParams.get('shell') // 'ollama' | null
+  const shellType = url.searchParams.get('shell') // 'ollama' | 'container' | null
+  const containerName = url.searchParams.get('container') // e.g. 'project-s-jellyfin'
 
   let cmd: string
   let args: string[]
@@ -50,7 +73,20 @@ wss.on('connection', async (ws: WebSocket, req: IncomingMessage) => {
   if (shellType === 'ollama') {
     cmd = 'docker'
     args = ['exec', '-it', 'project-s-ollama', '/bin/sh']
-    ws.send('\x1b[2m[connected to ollama]\x1b[0m\r\n')
+    ws.send('\x1b]0;ollama\x07') // set tab title via OSC
+    ws.send('\x1b[2m[connected to project-s-ollama]\x1b[0m\r\n')
+  } else if (shellType === 'container' && containerName) {
+    const running = await isContainerRunning(containerName)
+    if (!running) {
+      ws.send(`\r\n\x1b[31mContainer '${containerName}' is not running.\x1b[0m\r\n`)
+      ws.close()
+      return
+    }
+    cmd = 'docker'
+    args = ['exec', '-it', containerName, '/bin/sh']
+    const shortName = containerName.replace('project-s-', '')
+    ws.send(`\x1b]0;${shortName}\x07`) // set tab title via OSC
+    ws.send(`\x1b[2m[connected to ${containerName}]\x1b[0m\r\n`)
   } else {
     const useTheia = await isTheiaRunning()
     if (useTheia) {
@@ -77,8 +113,8 @@ wss.on('connection', async (ws: WebSocket, req: IncomingMessage) => {
     return
   }
 
-  // Inject ollama alias into Theia shell so 'ollama' works natively without relying on .bashrc timing
-  if (shellType !== 'ollama') {
+  // Inject ollama alias into Theia/bash shell so 'ollama' works natively
+  if (shellType !== 'ollama' && shellType !== 'container') {
     setTimeout(() => {
       if (shell) shell.write("alias ollama='docker exec -it project-s-ollama ollama'\n")
     }, 300)

--- a/Dashboard/Dashboard1/custom-server.ts
+++ b/Dashboard/Dashboard1/custom-server.ts
@@ -7,28 +7,6 @@ import * as pty from 'node-pty'
 const WS_PORT = parseInt(process.env.WS_PORT || '3070', 10)
 const hostname = '0.0.0.0'
 
-/** Check via Docker socket HTTP API — avoids docker CLI permission issues. */
-function isTheiaRunning(): Promise<boolean> {
-  return new Promise((resolve) => {
-    const req = httpGet({
-      socketPath: '/var/run/docker.sock',
-      path: '/containers/project-s-theia/json',
-    }, (res) => {
-      let data = ''
-      res.on('data', (chunk) => { data += chunk })
-      res.on('end', () => {
-        try {
-          const json = JSON.parse(data)
-          resolve(json?.State?.Running === true)
-        } catch {
-          resolve(false)
-        }
-      })
-    })
-    req.on('error', () => resolve(false))
-    req.setTimeout(2000, () => { req.destroy(); resolve(false) })
-  })
-}
 
 /** Check if a named container is running via Docker socket. */
 function isContainerRunning(name: string): Promise<boolean> {
@@ -88,15 +66,10 @@ wss.on('connection', async (ws: WebSocket, req: IncomingMessage) => {
     ws.send(`\x1b]0;${shortName}\x07`) // set tab title via OSC
     ws.send(`\x1b[2m[connected to ${containerName}]\x1b[0m\r\n`)
   } else {
-    const useTheia = await isTheiaRunning()
-    if (useTheia) {
-      cmd = 'docker'
-      args = ['exec', '-it', '-w', '/home/project/workspace', 'project-s-theia', '/bin/bash']
-      ws.send('\x1b[2m[connected to theia]\x1b[0m\r\n')
-    } else {
-      cmd = '/bin/bash'
-      args = []
-    }
+    // Unified shell — runs in the dashboard container which has docker.io installed.
+    // All docker/compose commands work natively. Theia IDE is at localhost:3030.
+    cmd = '/bin/bash'
+    args = []
   }
 
   try {
@@ -113,10 +86,14 @@ wss.on('connection', async (ws: WebSocket, req: IncomingMessage) => {
     return
   }
 
-  // Inject ollama alias into Theia/bash shell so 'ollama' works natively
+  // Inject convenience aliases into the default unified shell
   if (shellType !== 'ollama' && shellType !== 'container') {
     setTimeout(() => {
-      if (shell) shell.write("alias ollama='docker exec -it project-s-ollama ollama'\n")
+      if (shell) shell.write([
+        "alias ollama='docker exec -it project-s-ollama ollama'",
+        "alias theia='docker exec -it project-s-theia /bin/bash'",
+        "clear",
+      ].join(' && ') + '\n')
     }, 300)
   }
 

--- a/Project_S_Logs/17_Terminal_Redesign.md
+++ b/Project_S_Logs/17_Terminal_Redesign.md
@@ -1,4 +1,4 @@
-# Terminal Redesign: HomeForge (COMPLETED)
+# Terminal Redesign: HomeForge
 
 ## Architecture
 Browser (xterm.js) ←──WebSocket──→ Custom server (ws + node-pty) ←──PTY──→ /bin/bash
@@ -53,3 +53,68 @@ Rebuild and launch with:
 docker compose build dashboard
 docker compose up -d dashboard
 ```
+
+---
+
+## Phase 2: Terminal Integration & Unity (PR #90 — Issue #89)
+
+**Date:** 2026-04-04
+
+### Problems Fixed
+
+| # | Issue | Root Cause |
+|---|-------|------------|
+| 1 | `ws://` hardcoded — breaks over HTTPS | No protocol detection |
+| 2 | Ollama tab showed no context about which container was connected | Server sent no banner or title |
+| 3 | Stale closure in `closeTab` | `tabs` state passed as a workaround param instead of functional updater |
+| 4 | Sessions destroyed on panel close/reopen | `if (!open) return null` unmounted entire component tree |
+| 5 | No way to exec into a container from the dashboard | No integration between service tiles and terminal |
+| 6 | Tab titles static — never updated from the shell | `onTitleChange` not wired |
+
+### Solutions
+
+**Fix 1 — Protocol detection**
+`terminal-panel.tsx` now checks `window.location.protocol` and uses `wss://` when served over HTTPS.
+
+**Fix 2 — Context clarity for shell tabs**
+`custom-server.ts` sends an OSC title sequence (`\x1b]0;<name>\x07`) on connect so xterm.js picks it up as the tab title automatically. A `[connected to <container>]` banner is also written to the terminal.
+
+**Fix 3 — Stale closure**
+`closeTab` now uses a functional `setTabs(prev => ...)` updater. No longer requires `tabs` to be passed as a parameter from the render.
+
+**Fix 4 — Session persistence**
+Added a `hasEverOpened` ref. Once the panel opens for the first time, it stays in the DOM permanently. Closing the panel now uses `transform: translateY(100%)` (CSS off-screen) instead of unmounting — WebSocket connections and pty sessions survive.
+
+**Fix 5 — Exec into container from tiles**
+- Each container card in the "Active Infrastructure" section of the Dashboard now has a terminal icon button.
+- Clicking it sets `execTarget` in `page.tsx`, opens the terminal panel, and `TerminalPanel` opens a new tab with `?shell=container&container=<name>` connecting to that container via `docker exec -it`.
+- `custom-server.ts` validates the container is running before spawning. Returns an error message if not.
+- New `container` shell type with a distinct `<Container />` icon in the tab bar.
+
+**Fix 6 — Dynamic tab titles**
+`TerminalInstance` wires `terminal.onTitleChange` (xterm.js built-in) to a callback that updates tab title state in the parent. Works for all tab types.
+
+### Updated Architecture
+
+```
+Browser (xterm.js) ←─ ws/wss ─→ Custom WS server ←─ PTY ─→ shell context
+                                       │
+                              ?shell=ollama    → docker exec -it project-s-ollama /bin/sh
+                              ?shell=container → docker exec -it <container> /bin/sh
+                              (default)        → docker exec -it project-s-theia /bin/bash
+                                                 (fallback: /bin/bash on host)
+```
+
+Panel lifecycle:
+- First open → mount, create WS + pty
+- Close → `translateY(100%)`, sessions stay alive
+- Reopen → slide back, re-fit active terminal, sessions intact
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `custom-server.ts` | Add `?shell=container&container=<name>` support, container running check, OSC title on connect |
+| `components/dashboard/terminal-panel.tsx` | All 6 fixes above |
+| `components/dashboard/dashboard-section.tsx` | Terminal exec button on each container tile |
+| `app/page.tsx` | `execTarget` state wired between `DashboardSection` and `TerminalPanel` |

--- a/Project_S_Logs/17_Terminal_Redesign.md
+++ b/Project_S_Logs/17_Terminal_Redesign.md
@@ -101,8 +101,8 @@ Browser (xterm.js) ←─ ws/wss ─→ Custom WS server ←─ PTY ─→ shell
                                        │
                               ?shell=ollama    → docker exec -it project-s-ollama /bin/sh
                               ?shell=container → docker exec -it <container> /bin/sh
-                              (default)        → docker exec -it project-s-theia /bin/bash
-                                                 (fallback: /bin/bash on host)
+                              (default)        → /bin/bash in dashboard container (docker.io installed)
+                                                 aliases: ollama, theia
 ```
 
 Panel lifecycle:
@@ -114,7 +114,42 @@ Panel lifecycle:
 
 | File | Change |
 |------|--------|
-| `custom-server.ts` | Add `?shell=container&container=<name>` support, container running check, OSC title on connect |
+| `custom-server.ts` | Add `?shell=container&container=<name>` support, container running check, OSC title on connect, unified default shell |
 | `components/dashboard/terminal-panel.tsx` | All 6 fixes above |
 | `components/dashboard/dashboard-section.tsx` | Terminal exec button on each container tile |
 | `app/page.tsx` | `execTarget` state wired between `DashboardSection` and `TerminalPanel` |
+
+---
+
+## Phase 3: Unified Terminal Shell (closes #91)
+
+**Date:** 2026-04-04
+
+### Problem
+The default terminal tab exec'd into the Theia container, which doesn't have the Docker CLI installed. This meant `ollama` and all `docker` commands failed from the default shell. Users had to switch to a dedicated Ollama tab or container tab to run anything docker-related.
+
+### Solution
+Removed the `isTheiaRunning()` check and Theia exec routing entirely. The default shell is now `/bin/bash` running inside the **dashboard container**, which already has `docker.io` installed.
+
+On shell start, two aliases are injected automatically:
+```bash
+alias ollama='docker exec -it project-s-ollama ollama'
+alias theia='docker exec -it project-s-theia /bin/bash'
+```
+
+This gives one unified terminal where you can:
+- Run `docker ps`, `docker compose logs <service>`, `docker exec` — all natively
+- Run `ollama list`, `ollama run llama3.2` — via alias
+- Jump into Theia workspace with `theia` — via alias
+- Use dedicated Ollama/container tabs as optional shortcuts
+
+Theia IDE remains accessible at `localhost:3030` in the browser for workspace use.
+
+### What was removed
+- `isTheiaRunning()` function — no longer needed
+- Theia exec routing in the default shell path
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `custom-server.ts` | Remove `isTheiaRunning`, default shell is now `/bin/bash` in dashboard container, expanded aliases |


### PR DESCRIPTION
## Summary

Closes #89
Closes #91

Fixes all 6 terminal issues from #89 plus the unified shell (#91).

---

## Changes

### Fix 1 — `ws://` → `wss://` (protocol detection)
Detects `window.location.protocol` and uses `wss://` when served over HTTPS.

### Fix 2 — Ollama tab context clarity
Server sends OSC title sequence + `[connected to project-s-ollama]` banner on connect.

### Fix 3 — Stale closure in `closeTab`
Uses functional `setTabs` updater — no more passing `tabs` as a workaround param.

### Fix 4 — Session persistence
`hasEverOpened` ref + CSS `translateY(100%)` keeps panel in DOM after first open. WS/pty sessions survive close/reopen. Verified with `/tmp` file test.

### Fix 5 — Exec into container from dashboard tiles
Terminal icon on every container card in "Active Infrastructure". Opens a new exec tab directly into that container via `docker exec -it`.

### Fix 6 — Dynamic tab titles
`terminal.onTitleChange` wired to tab state. Server sends OSC title on connect for ollama and container tabs.

### Fix 7 — Unified shell (#91)
Removed `isTheiaRunning()` routing. Default shell is now `/bin/bash` in the dashboard container (has `docker.io` installed). Pre-loads `ollama` and `theia` aliases on start. One terminal, full docker access.

---

## Verified
- `ollama list` works from default tab
- `docker ps` shows full stack
- `theia` alias jumps into Theia container, `exit` returns to unified shell
- Session persistence confirmed — `/tmp` files survive panel close/reopen

## Files Changed
- `custom-server.ts`
- `components/dashboard/terminal-panel.tsx`
- `components/dashboard/dashboard-section.tsx`
- `app/page.tsx`
- `Project_S_Logs/17_Terminal_Redesign.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)