### PR TITLE
fix: pin synapse-db to postgres:15-alpine — data volume version mismatch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,7 +167,7 @@ services:
       start_period: 30s
 
   synapse-db:
-    image: postgres:16-alpine
+    image: postgres:15-alpine  # data volume was initialized with PG15 — do NOT bump without pg_upgrade
     container_name: project-s-matrix-db
     environment:
       - POSTGRES_USER=${MATRIX_DB_USER}


### PR DESCRIPTION
## Summary

Closes #92

Pins `synapse-db` back to `postgres:15-alpine`. The data volume (`./data/matrix/db`) was initialized with PostgreSQL 15 and cannot be read by PG16 without a `pg_upgrade` migration.

## Root Cause

This is the **third time** this has been re-introduced. The image keeps getting bumped back to `postgres:16` as a side effect of unrelated PRs that touch `docker-compose.yml` (most recently the Collabora fix in #51). Added an inline comment on the image line to make the constraint visible to future PRs:

```yaml
image: postgres:15-alpine  # data volume was initialized with PG15 — do NOT bump without pg_upgrade
```

## Verified

Both containers came up healthy immediately after the fix:
- `project-s-matrix-db` — Up, stable
- `project-s-matrix-server` — Up, healthy

## Future Work
To properly upgrade to PG16, a `pg_dumpall` → restore migration is required. Track separately.

## Test plan
- [ ] Confirm `project-s-matrix-db` stays up (not restarting) after merge
- [ ] Confirm `project-s-matrix-server` shows healthy
- [ ] Confirm Element UI at port 8082 is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)