### PR TITLE
fix: Ollama ↔ Open-WebUI backend integration and hardening (closes #88)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,9 @@ MATRIX_DB_NAME=synapse
 # Admin credentials for the OpenVPN web UI (http://<host>:8087)
 VPN_ADMIN_USERNAME=admin
 VPN_ADMIN_PASSWORD=change_me_vpn_password
+
+# --- Open-WebUI --------------------------------------------------------------
+# IMPORTANT: Generate a unique secret key — never reuse or commit it.
+# Changing this value logs out all users and invalidates all sessions.
+# Generate with: openssl rand -base64 32
+WEBUI_SECRET_KEY=change_me_generate_with_openssl_rand_base64_32

--- a/Dashboard/Dashboard1/app/api/ollama/route.ts
+++ b/Dashboard/Dashboard1/app/api/ollama/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+import { get as httpGet } from 'http'
+
+const OLLAMA_BASE = process.env.OLLAMA_BASE_URL || 'http://ollama:11434'
+
+/**
+ * Proxy for Ollama API — called from the dashboard frontend.
+ * Runs server-side so the browser never needs direct access to port 11434.
+ * Works regardless of how HomeForge is accessed (localhost, LAN IP, domain).
+ */
+export async function GET() {
+  return new Promise<NextResponse>((resolve) => {
+    const req = httpGet(`${OLLAMA_BASE}/api/tags`, { timeout: 5000 }, (res) => {
+      let data = ''
+      res.on('data', (chunk) => { data += chunk })
+      res.on('end', () => {
+        try {
+          resolve(NextResponse.json(JSON.parse(data)))
+        } catch {
+          resolve(NextResponse.json({ error: 'Invalid response from Ollama' }, { status: 502 }))
+        }
+      })
+    })
+    req.on('error', (err) => {
+      resolve(NextResponse.json({ error: err.message }, { status: 503 }))
+    })
+    req.on('timeout', () => {
+      req.destroy()
+      resolve(NextResponse.json({ error: 'Ollama connection timed out' }, { status: 504 }))
+    })
+  })
+}

--- a/Dashboard/Dashboard1/components/dashboard/ollama-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/ollama-section.tsx
@@ -23,17 +23,19 @@ function formatSize(bytes: number): string {
 
 export function OllamaSection({ isWindow }: OllamaSectionProps) {
   const { colorTheme, mode } = useTheme()
-  const [ollamaUrl, setOllamaUrl] = useState("")
   const [models, setModels] = useState<OllamaModel[]>([])
   const [healthy, setHealthy] = useState<boolean | null>(null)
   const [loading, setLoading] = useState(true)
 
-  const fetchModels = useCallback(async (baseUrl: string) => {
+  // Proxy through /api/ollama — never hits port 11434 directly from the browser.
+  // Works regardless of how HomeForge is accessed (localhost, LAN IP, domain, reverse proxy).
+  const fetchModels = useCallback(async () => {
     setLoading(true)
     try {
-      const res = await fetch(`${baseUrl}/api/tags`)
+      const res = await fetch('/api/ollama')
       if (!res.ok) throw new Error('not ok')
       const data = await res.json()
+      if (data.error) throw new Error(data.error)
       setModels(data.models || [])
       setHealthy(true)
     } catch {
@@ -45,9 +47,7 @@ export function OllamaSection({ isWindow }: OllamaSectionProps) {
   }, [])
 
   useEffect(() => {
-    const base = `http://${window.location.hostname}:11434`
-    setOllamaUrl(base)
-    fetchModels(base)
+    fetchModels()
   }, [fetchModels])
 
   const content = (
@@ -86,7 +86,7 @@ export function OllamaSection({ isWindow }: OllamaSectionProps) {
           </div>
         </div>
         <button
-          onClick={() => ollamaUrl && fetchModels(ollamaUrl)}
+          onClick={() => fetchModels()}
           disabled={loading}
           className="p-1.5 rounded-lg transition-opacity opacity-40 hover:opacity-100 disabled:opacity-20"
           style={{ color: colorTheme.foreground }}
@@ -107,7 +107,7 @@ export function OllamaSection({ isWindow }: OllamaSectionProps) {
               </p>
               <p className="text-xs opacity-40 max-w-xs" style={{ color: colorTheme.foreground }}>
                 Make sure the Ollama container is running. It should be accessible at{' '}
-                <code className="font-mono">{ollamaUrl}</code>.
+                <code className="font-mono">project-s-ollama:11434</code>.
               </p>
             </div>
           </div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,19 +237,25 @@ services:
       - ./data/open-webui:/app/backend/data
     environment:
       - OLLAMA_BASE_URL=http://ollama:11434
+      - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY}
+      - CORS_ALLOW_ORIGIN=http://localhost:8085,http://localhost:3069,http://${HOMEFORGE_LAN_IP:-localhost}:8085,http://${HOMEFORGE_LAN_IP:-localhost}:3069
+      - WEBUI_AUTH=true
+      - JWT_EXPIRES_IN=7d
+      - ENABLE_PASSWORD_VALIDATION=true
     depends_on:
-      - ollama
+      ollama:
+        condition: service_healthy
     restart: unless-stopped
     deploy:
       resources:
         limits:
           memory: 2g
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 30s
+      start_period: 60s
 
   ollama:
     image: ollama/ollama:0.6.5


### PR DESCRIPTION
## Summary

Closes #88

7 issues fixed across `docker-compose.yml`, the Next.js dashboard, and `.env.example`.

---

## Changes

### 1. Healthcheck fixed
`/health` endpoint doesn't exist in open-webui. Changed to `curl -sf http://localhost:8080/` (curl is present in the image). Bumped `start_period` to 60s to account for boot time.

### 2. depends_on uses service_healthy
Open-WebUI now waits for Ollama to pass its healthcheck before starting — no more race condition on boot. Verified: Docker shows `Waiting → Healthy → Starting` sequence in logs.

### 3. CORS scoped to LAN IP
`CORS_ALLOW_ORIGIN` now set explicitly to `localhost` + `HOMEFORGE_LAN_IP` on both the dashboard and Open-WebUI ports. No more wildcard `*`.

### 4. WEBUI_SECRET_KEY added
Sessions now survive container restarts and redeployments. Key sourced from `.env` (gitignored). `.env.example` updated with generation instructions.

### 5. Security hardening vars added
`WEBUI_AUTH=true`, `JWT_EXPIRES_IN=7d`, `ENABLE_PASSWORD_VALIDATION=true` all set explicitly.

### 6. Ollama API proxied through Next.js
New route: `Dashboard/Dashboard1/app/api/ollama/route.ts`

`ollama-section.tsx` now calls `/api/ollama` (server-side proxy to `http://ollama:11434`) instead of hitting port 11434 directly from the browser. Works from any device, any network — critical for a product deployed on remote servers.

### 7. .env.example updated
Added Open-WebUI section with `WEBUI_SECRET_KEY` and generation instructions so new installs are guided correctly.

---

## Verified
- Both `project-s-ollama` and `project-s-open-webui` show `healthy`
- `depends_on: service_healthy` confirmed working — webui waited for ollama on startup
- TypeScript: zero errors

## Test plan
- [ ] Open dashboard Ollama section — models should load without hitting port 11434
- [ ] Restart `open-webui` container — session should survive (WEBUI_SECRET_KEY set)
- [ ] Access HomeForge from another device on the LAN — Ollama section should still work
- [ ] Check `docker logs project-s-open-webui` — no CORS wildcard warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)