### PR TITLE
feat: Ollama model manager — pull, delete, running state, model details

### DIFF
--- a/Dashboard/Dashboard1/app/api/ollama/delete/route.ts
+++ b/Dashboard/Dashboard1/app/api/ollama/delete/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { request as httpRequest } from 'http'
+
+const OLLAMA_BASE = process.env.OLLAMA_BASE_URL || 'http://ollama:11434'
+
+export async function DELETE(req: NextRequest) {
+  const body = await req.json()
+
+  return new Promise<NextResponse>((resolve) => {
+    const payload = JSON.stringify({ name: body.name })
+    const url = new URL(`${OLLAMA_BASE}/api/delete`)
+
+    const options = {
+      hostname: url.hostname,
+      port: Number(url.port) || 11434,
+      path: '/api/delete',
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+      },
+      timeout: 10000,
+    }
+
+    const ollamaReq = httpRequest(options, (res) => {
+      // Ollama returns 200 with empty body on success
+      res.resume()
+      res.on('end', () => {
+        if (res.statusCode === 200) {
+          resolve(NextResponse.json({ ok: true }))
+        } else {
+          resolve(NextResponse.json({ error: `Ollama returned ${res.statusCode}` }, { status: res.statusCode ?? 500 }))
+        }
+      })
+    })
+
+    ollamaReq.on('error', (err) => {
+      resolve(NextResponse.json({ error: err.message }, { status: 503 }))
+    })
+    ollamaReq.on('timeout', () => {
+      ollamaReq.destroy()
+      resolve(NextResponse.json({ error: 'Ollama connection timed out' }, { status: 504 }))
+    })
+
+    ollamaReq.write(payload)
+    ollamaReq.end()
+  })
+}

--- a/Dashboard/Dashboard1/app/api/ollama/ps/route.ts
+++ b/Dashboard/Dashboard1/app/api/ollama/ps/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+import { get as httpGet } from 'http'
+
+const OLLAMA_BASE = process.env.OLLAMA_BASE_URL || 'http://ollama:11434'
+
+export async function GET() {
+  return new Promise<NextResponse>((resolve) => {
+    const req = httpGet(`${OLLAMA_BASE}/api/ps`, { timeout: 5000 }, (res) => {
+      let data = ''
+      res.on('data', (chunk) => { data += chunk })
+      res.on('end', () => {
+        try {
+          resolve(NextResponse.json(JSON.parse(data)))
+        } catch {
+          resolve(NextResponse.json({ error: 'Invalid response from Ollama' }, { status: 502 }))
+        }
+      })
+    })
+    req.on('error', (err) => {
+      resolve(NextResponse.json({ error: err.message }, { status: 503 }))
+    })
+    req.on('timeout', () => {
+      req.destroy()
+      resolve(NextResponse.json({ error: 'Ollama connection timed out' }, { status: 504 }))
+    })
+  })
+}

--- a/Dashboard/Dashboard1/app/api/ollama/pull/route.ts
+++ b/Dashboard/Dashboard1/app/api/ollama/pull/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest } from 'next/server'
+import { request as httpRequest } from 'http'
+
+const OLLAMA_BASE = process.env.OLLAMA_BASE_URL || 'http://ollama:11434'
+
+export async function POST(req: NextRequest) {
+  const { name } = await req.json()
+  const payload = JSON.stringify({ name, stream: true })
+  const url = new URL(`${OLLAMA_BASE}/api/pull`)
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const options = {
+        hostname: url.hostname,
+        port: Number(url.port) || 11434,
+        path: '/api/pull',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+        },
+      }
+
+      const ollamaReq = httpRequest(options, (res) => {
+        res.on('data', (chunk: Buffer) => {
+          controller.enqueue(chunk)
+        })
+        res.on('end', () => {
+          controller.close()
+        })
+        res.on('error', (err) => {
+          controller.error(err)
+        })
+      })
+
+      ollamaReq.on('error', (err) => {
+        controller.error(err)
+      })
+
+      ollamaReq.write(payload)
+      ollamaReq.end()
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'application/x-ndjson',
+      'Transfer-Encoding': 'chunked',
+      'Cache-Control': 'no-cache',
+    },
+  })
+}

--- a/Dashboard/Dashboard1/app/api/ollama/show/route.ts
+++ b/Dashboard/Dashboard1/app/api/ollama/show/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { request as httpRequest } from 'http'
+
+const OLLAMA_BASE = process.env.OLLAMA_BASE_URL || 'http://ollama:11434'
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+
+  return new Promise<NextResponse>((resolve) => {
+    const payload = JSON.stringify({ name: body.name })
+    const url = new URL(`${OLLAMA_BASE}/api/show`)
+
+    const options = {
+      hostname: url.hostname,
+      port: Number(url.port) || 11434,
+      path: '/api/show',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+      },
+      timeout: 10000,
+    }
+
+    const ollamaReq = httpRequest(options, (res) => {
+      let data = ''
+      res.on('data', (chunk) => { data += chunk })
+      res.on('end', () => {
+        try {
+          resolve(NextResponse.json(JSON.parse(data)))
+        } catch {
+          resolve(NextResponse.json({ error: 'Invalid response from Ollama' }, { status: 502 }))
+        }
+      })
+    })
+
+    ollamaReq.on('error', (err) => {
+      resolve(NextResponse.json({ error: err.message }, { status: 503 }))
+    })
+    ollamaReq.on('timeout', () => {
+      ollamaReq.destroy()
+      resolve(NextResponse.json({ error: 'Ollama connection timed out' }, { status: 504 }))
+    })
+
+    ollamaReq.write(payload)
+    ollamaReq.end()
+  })
+}

--- a/Dashboard/Dashboard1/app/page.tsx
+++ b/Dashboard/Dashboard1/app/page.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from "@/components/dashboard/sidebar"
 import { WelcomeSection } from "@/components/dashboard/welcome-section"
 import { DashboardSection } from "@/components/dashboard/dashboard-section"
 import { MetricsSection } from "@/components/dashboard/metrics-section"
+import { OllamaSection } from "@/components/dashboard/ollama-section"
 import { TerminalPanel } from "@/components/dashboard/terminal-panel"
 import { useTheme } from "@/components/theme-provider"
 import { cn } from "@/lib/utils"
@@ -101,6 +102,14 @@ export default function HomePage() {
 
       <main className="relative z-10 h-full w-full">
         {/* HOME / METRICS VIEW (Static / Scrollable) */}
+        {/* OLLAMA SECTION */}
+        <div className={cn(
+          "h-full w-full transition-all duration-500",
+          currentSection === "ollama" ? "opacity-100 scale-100" : "opacity-0 scale-95 pointer-events-none absolute inset-0"
+        )}>
+          <OllamaSection />
+        </div>
+
         <div className={cn(
           "h-full w-full transition-all duration-500",
           (currentSection === "home" || currentSection === "metrics") ? "opacity-100 scale-100" : "opacity-0 scale-95 pointer-events-none absolute inset-0"

--- a/Dashboard/Dashboard1/components/dashboard/ollama-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/ollama-section.tsx
@@ -1,14 +1,37 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { useTheme } from "@/components/theme-provider"
 import { cn } from "@/lib/utils"
-import { BrainCircuit, RefreshCw, HardDrive } from "lucide-react"
+import { BrainCircuit, RefreshCw, HardDrive, Trash2, Download, X, ChevronRight, Cpu } from "lucide-react"
 
 interface OllamaModel {
   name: string
   size: number
   modified_at: string
+}
+
+interface OllamaShowResponse {
+  modelfile?: string
+  parameters?: string
+  template?: string
+  details?: {
+    parent_model?: string
+    format?: string
+    family?: string
+    families?: string[]
+    parameter_size?: string
+    quantization_level?: string
+  }
+  model_info?: Record<string, unknown>
+}
+
+interface PullProgress {
+  status: string
+  total: number
+  completed: number
+  percent: number
+  error?: string
 }
 
 interface OllamaSectionProps {
@@ -21,14 +44,35 @@ function formatSize(bytes: number): string {
   return `${(bytes / 1024).toFixed(1)} KB`
 }
 
+// Normalize model names — "llama3.2:latest" and "llama3.2" both become "llama3.2"
+function modelBase(name: string): string {
+  return name.split(':')[0]
+}
+
 export function OllamaSection({ isWindow }: OllamaSectionProps) {
   const { colorTheme, mode } = useTheme()
   const [models, setModels] = useState<OllamaModel[]>([])
   const [healthy, setHealthy] = useState<boolean | null>(null)
   const [loading, setLoading] = useState(true)
 
+  // Running models (from /api/ps)
+  const [runningModels, setRunningModels] = useState<Set<string>>(new Set())
+
+  // Pull state
+  const [pullInput, setPullInput] = useState('')
+  const [isPulling, setIsPulling] = useState(false)
+  const [pullProgress, setPullProgress] = useState<Record<string, PullProgress>>({})
+  const abortRef = useRef<AbortController | null>(null)
+
+  // Delete confirm
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null)
+
+  // Details drawer
+  const [drawerModel, setDrawerModel] = useState<string | null>(null)
+  const [drawerData, setDrawerData] = useState<OllamaShowResponse | null>(null)
+  const [drawerLoading, setDrawerLoading] = useState(false)
+
   // Proxy through /api/ollama — never hits port 11434 directly from the browser.
-  // Works regardless of how HomeForge is accessed (localhost, LAN IP, domain, reverse proxy).
   const fetchModels = useCallback(async () => {
     setLoading(true)
     try {
@@ -50,10 +94,155 @@ export function OllamaSection({ isWindow }: OllamaSectionProps) {
     fetchModels()
   }, [fetchModels])
 
+  // Poll /api/ps every 5s to keep running-model state fresh
+  useEffect(() => {
+    const poll = async () => {
+      try {
+        const res = await fetch('/api/ollama/ps')
+        if (!res.ok) return
+        const data = await res.json()
+        setRunningModels(new Set(
+          (data.models || []).map((m: { name: string }) => modelBase(m.name))
+        ))
+      } catch { /* silently ignore */ }
+    }
+    poll()
+    const id = setInterval(poll, 5000)
+    return () => clearInterval(id)
+  }, [])
+
+  // Remove 'success' pull progress entries after 3s
+  useEffect(() => {
+    const successKeys = Object.entries(pullProgress)
+      .filter(([, v]) => v.status === 'success')
+      .map(([k]) => k)
+    if (successKeys.length === 0) return
+    const id = setTimeout(() => {
+      setPullProgress(prev => {
+        const next = { ...prev }
+        successKeys.forEach(k => delete next[k])
+        return next
+      })
+    }, 3000)
+    return () => clearTimeout(id)
+  }, [pullProgress])
+
+  // Abort any in-progress pull on unmount
+  useEffect(() => {
+    return () => { abortRef.current?.abort() }
+  }, [])
+
+  const handlePull = async () => {
+    const name = pullInput.trim()
+    if (!name || isPulling) return
+
+    const ctrl = new AbortController()
+    abortRef.current = ctrl
+    setIsPulling(true)
+    setPullProgress(prev => ({
+      ...prev,
+      [name]: { status: 'starting', total: 0, completed: 0, percent: 0 },
+    }))
+
+    try {
+      const res = await fetch('/api/ollama/pull', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+        signal: ctrl.signal,
+      })
+      if (!res.body) throw new Error('No stream')
+
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() ?? ''
+
+        for (const line of lines) {
+          if (!line.trim()) continue
+          try {
+            const msg = JSON.parse(line)
+            const total = msg.total ?? 0
+            const completed = msg.completed ?? 0
+            setPullProgress(prev => ({
+              ...prev,
+              [name]: {
+                status: msg.status ?? 'pulling',
+                total,
+                completed,
+                percent: total > 0 ? Math.round((completed / total) * 100) : 0,
+                error: msg.error,
+              },
+            }))
+          } catch { /* malformed NDJSON chunk, skip */ }
+        }
+      }
+
+      await fetchModels()
+      setPullInput('')
+      setPullProgress(prev => ({
+        ...prev,
+        [name]: { status: 'success', total: 1, completed: 1, percent: 100 },
+      }))
+    } catch (e: unknown) {
+      if (e instanceof Error && e.name === 'AbortError') return
+      setPullProgress(prev => ({
+        ...prev,
+        [name]: { status: 'error', total: 0, completed: 0, percent: 0, error: String(e) },
+      }))
+    } finally {
+      setIsPulling(false)
+    }
+  }
+
+  const handleDelete = async (name: string) => {
+    setDeleteConfirm(null)
+    const snapshot = models
+    setModels(prev => prev.filter(m => m.name !== name))
+    try {
+      const res = await fetch('/api/ollama/delete', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      })
+      if (!res.ok) throw new Error('Delete failed')
+    } catch {
+      setModels(snapshot) // rollback on error
+    }
+  }
+
+  const handleOpenDrawer = async (name: string) => {
+    setDrawerModel(name)
+    setDrawerData(null)
+    setDrawerLoading(true)
+    try {
+      const res = await fetch('/api/ollama/show', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      })
+      setDrawerData(await res.json())
+    } catch {
+      setDrawerData(null)
+    } finally {
+      setDrawerLoading(false)
+    }
+  }
+
+  const isRunning = (name: string) => runningModels.has(modelBase(name))
+
+  const activePulls = Object.entries(pullProgress).filter(([, v]) => v.status !== 'success')
+
   const content = (
     <div
       className={cn(
-        "flex-1 w-full overflow-hidden flex flex-col",
+        "flex-1 w-full overflow-hidden flex flex-col relative",
         !isWindow && "rounded-2xl border"
       )}
       style={!isWindow ? {
@@ -64,10 +253,11 @@ export function OllamaSection({ isWindow }: OllamaSectionProps) {
     >
       {/* Header bar */}
       <div
-        className="shrink-0 flex items-center justify-between gap-3 px-4 py-3 border-b"
+        className="shrink-0 flex items-center gap-3 px-4 py-3 border-b"
         style={{ borderColor: colorTheme.border }}
       >
-        <div className="flex items-center gap-2">
+        {/* Title + health badge */}
+        <div className="flex items-center gap-2 shrink-0">
           <BrainCircuit className="h-4 w-4" style={{ color: colorTheme.accent }} />
           <span className="text-sm font-semibold" style={{ color: colorTheme.foreground }}>Ollama</span>
           <div className={cn(
@@ -85,10 +275,35 @@ export function OllamaSection({ isWindow }: OllamaSectionProps) {
             {healthy === true ? 'Online' : healthy === false ? 'Offline' : 'Checking'}
           </div>
         </div>
+
+        {/* Pull input + button */}
+        <div className="flex-1 flex items-center gap-2 min-w-0">
+          <input
+            type="text"
+            value={pullInput}
+            onChange={e => setPullInput(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && handlePull()}
+            placeholder="model:tag  e.g. llama3.2"
+            disabled={isPulling}
+            className="flex-1 min-w-0 text-xs px-2.5 py-1.5 rounded-lg border bg-transparent outline-none disabled:opacity-40"
+            style={{ borderColor: colorTheme.border, color: colorTheme.foreground }}
+          />
+          <button
+            onClick={handlePull}
+            disabled={isPulling || !pullInput.trim()}
+            className="shrink-0 flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold transition-opacity disabled:opacity-30"
+            style={{ backgroundColor: `${colorTheme.accent}20`, color: colorTheme.accent }}
+          >
+            <Download className={cn("h-3 w-3", isPulling && "animate-bounce")} />
+            {isPulling ? 'Pulling…' : 'Pull'}
+          </button>
+        </div>
+
+        {/* Refresh */}
         <button
           onClick={() => fetchModels()}
           disabled={loading}
-          className="p-1.5 rounded-lg transition-opacity opacity-40 hover:opacity-100 disabled:opacity-20"
+          className="shrink-0 p-1.5 rounded-lg transition-opacity opacity-40 hover:opacity-100 disabled:opacity-20"
           style={{ color: colorTheme.foreground }}
           title="Refresh"
         >
@@ -96,7 +311,54 @@ export function OllamaSection({ isWindow }: OllamaSectionProps) {
         </button>
       </div>
 
-      {/* Content */}
+      {/* Active pull progress bars */}
+      {activePulls.length > 0 && (
+        <div
+          className="shrink-0 px-4 py-2 space-y-2 border-b"
+          style={{ borderColor: colorTheme.border }}
+        >
+          {activePulls.map(([name, progress]) => (
+            <div key={name}>
+              <div className="flex items-center justify-between mb-1">
+                <span
+                  className="text-[10px] font-mono truncate max-w-[65%]"
+                  style={{ color: colorTheme.foreground }}
+                >
+                  {name}
+                </span>
+                <span className="text-[10px] opacity-50" style={{ color: colorTheme.foreground }}>
+                  {progress.error
+                    ? 'Error'
+                    : progress.total > 0
+                      ? `${progress.percent}%`
+                      : progress.status}
+                </span>
+              </div>
+              <div
+                className="h-1 w-full rounded-full overflow-hidden"
+                style={{ backgroundColor: `${colorTheme.border}` }}
+              >
+                {progress.error ? (
+                  <div className="h-full w-full rounded-full bg-red-500/60" />
+                ) : progress.total === 0 ? (
+                  // Indeterminate: manifest / verify phase
+                  <div
+                    className="h-full w-1/3 rounded-full animate-pulse"
+                    style={{ backgroundColor: colorTheme.accent }}
+                  />
+                ) : (
+                  <div
+                    className="h-full rounded-full transition-all duration-300"
+                    style={{ width: `${progress.percent}%`, backgroundColor: colorTheme.accent }}
+                  />
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Model list */}
       <div className="flex-1 overflow-y-auto p-4">
         {healthy === false ? (
           <div className="flex flex-col items-center justify-center h-full gap-4 text-center p-8">
@@ -119,47 +381,268 @@ export function OllamaSection({ isWindow }: OllamaSectionProps) {
                 No models pulled yet
               </p>
               <p className="text-xs opacity-40 max-w-xs" style={{ color: colorTheme.foreground }}>
-                Open the terminal and run{' '}
-                <code className="font-mono px-1 py-0.5 rounded"
-                  style={{ backgroundColor: `${colorTheme.accent}20`, color: colorTheme.accent }}>
-                  docker exec project-s-ollama ollama pull llama3.2
-                </code>{' '}
-                to download your first model.
+                Type a model name above and click Pull — e.g.{' '}
+                <code
+                  className="font-mono px-1 py-0.5 rounded"
+                  style={{ backgroundColor: `${colorTheme.accent}20`, color: colorTheme.accent }}
+                >
+                  llama3.2
+                </code>
               </p>
             </div>
           </div>
         ) : (
           <div className="space-y-2">
-            <p className="text-xs font-bold uppercase tracking-wider opacity-40 mb-3" style={{ color: colorTheme.foreground }}>
+            <p
+              className="text-xs font-bold uppercase tracking-wider opacity-40 mb-3"
+              style={{ color: colorTheme.foreground }}
+            >
               {models.length} {models.length === 1 ? 'model' : 'models'} available
             </p>
             {models.map(model => (
-              <div
-                key={model.name}
-                className="flex items-center justify-between p-3 rounded-xl border transition-colors"
-                style={{
-                  borderColor: colorTheme.border,
-                  backgroundColor: mode === 'dark' ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.02)',
-                }}
-              >
-                <div className="flex items-center gap-3">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-lg"
-                    style={{ backgroundColor: `${colorTheme.accent}15` }}>
-                    <BrainCircuit className="h-4 w-4" style={{ color: colorTheme.accent }} />
+              <div key={model.name}>
+                <div
+                  className="group flex items-center justify-between p-3 rounded-xl border transition-colors cursor-pointer"
+                  style={{
+                    borderColor: colorTheme.border,
+                    backgroundColor: mode === 'dark' ? 'rgba(255,255,255,0.02)' : 'rgba(0,0,0,0.02)',
+                  }}
+                  onClick={() => {
+                    if (deleteConfirm === model.name) return
+                    handleOpenDrawer(model.name)
+                  }}
+                >
+                  {/* Icon + name + running badge */}
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div
+                      className="shrink-0 flex h-8 w-8 items-center justify-center rounded-lg"
+                      style={{ backgroundColor: `${colorTheme.accent}15` }}
+                    >
+                      <BrainCircuit className="h-4 w-4" style={{ color: colorTheme.accent }} />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <p className="text-sm font-semibold truncate" style={{ color: colorTheme.foreground }}>
+                          {model.name}
+                        </p>
+                        {isRunning(model.name) && (
+                          <span className="flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[9px] font-bold uppercase bg-green-500/15 text-green-500 shrink-0">
+                            <Cpu className="h-2.5 w-2.5" />
+                            Loaded
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-[10px] opacity-40" style={{ color: colorTheme.foreground }}>
+                        {new Date(model.modified_at).toLocaleDateString()}
+                      </p>
+                    </div>
                   </div>
-                  <div>
-                    <p className="text-sm font-semibold" style={{ color: colorTheme.foreground }}>{model.name}</p>
-                    <p className="text-[10px] opacity-40" style={{ color: colorTheme.foreground }}>
-                      {new Date(model.modified_at).toLocaleDateString()}
-                    </p>
+
+                  {/* Size + delete + chevron */}
+                  <div className="flex items-center gap-2 shrink-0">
+                    <div className="flex items-center gap-1 opacity-40" style={{ color: colorTheme.foreground }}>
+                      <HardDrive className="h-3 w-3" />
+                      <span className="text-xs">{formatSize(model.size)}</span>
+                    </div>
+
+                    {deleteConfirm === model.name ? (
+                      <div className="flex items-center gap-1" onClick={e => e.stopPropagation()}>
+                        <button
+                          onClick={() => handleDelete(model.name)}
+                          className="px-2 py-0.5 rounded text-[10px] font-semibold bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors"
+                        >
+                          Delete
+                        </button>
+                        <button
+                          onClick={() => setDeleteConfirm(null)}
+                          className="px-2 py-0.5 rounded text-[10px] font-semibold opacity-50 hover:opacity-100 transition-opacity"
+                          style={{ color: colorTheme.foreground }}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        onClick={e => { e.stopPropagation(); setDeleteConfirm(model.name) }}
+                        className="opacity-0 group-hover:opacity-40 hover:!opacity-100 transition-opacity p-1 rounded"
+                        style={{ color: colorTheme.foreground }}
+                        title="Delete model"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    )}
+
+                    <ChevronRight className="h-3.5 w-3.5 opacity-20" style={{ color: colorTheme.foreground }} />
                   </div>
-                </div>
-                <div className="flex items-center gap-1 opacity-40" style={{ color: colorTheme.foreground }}>
-                  <HardDrive className="h-3 w-3" />
-                  <span className="text-xs">{formatSize(model.size)}</span>
                 </div>
               </div>
             ))}
+          </div>
+        )}
+      </div>
+
+      {/* Drawer backdrop */}
+      {drawerModel && (
+        <div
+          className="absolute inset-0 z-10"
+          style={{ backgroundColor: 'rgba(0,0,0,0.35)' }}
+          onClick={() => setDrawerModel(null)}
+        />
+      )}
+
+      {/* Details drawer */}
+      <div
+        className={cn(
+          "absolute top-0 right-0 bottom-0 w-72 z-20 flex flex-col border-l",
+          "transition-transform duration-300 ease-in-out",
+          drawerModel ? "translate-x-0" : "translate-x-full"
+        )}
+        style={{
+          backgroundColor: mode === 'dark' ? 'rgba(10,10,10,0.92)' : 'rgba(250,250,250,0.95)',
+          borderColor: colorTheme.border,
+          backdropFilter: 'blur(24px)',
+        }}
+      >
+        {/* Drawer header */}
+        <div
+          className="shrink-0 flex items-center justify-between px-4 py-3 border-b"
+          style={{ borderColor: colorTheme.border }}
+        >
+          <div className="flex items-center gap-2 min-w-0">
+            <BrainCircuit className="h-4 w-4 shrink-0" style={{ color: colorTheme.accent }} />
+            <span className="text-sm font-semibold truncate" style={{ color: colorTheme.foreground }}>
+              {drawerModel}
+            </span>
+          </div>
+          <button
+            onClick={() => setDrawerModel(null)}
+            className="shrink-0 p-1 rounded opacity-40 hover:opacity-100 transition-opacity"
+            style={{ color: colorTheme.foreground }}
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Drawer body */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {drawerLoading ? (
+            <div className="flex items-center justify-center h-24">
+              <RefreshCw className="h-5 w-5 animate-spin opacity-30" style={{ color: colorTheme.foreground }} />
+            </div>
+          ) : drawerData ? (
+            <>
+              {drawerData.details && (
+                <div className="space-y-2">
+                  <p className="text-[10px] font-bold uppercase tracking-wider opacity-40" style={{ color: colorTheme.foreground }}>
+                    Details
+                  </p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {drawerData.details.parameter_size && (
+                      <span
+                        className="px-2 py-0.5 rounded-full text-[10px] font-semibold"
+                        style={{ backgroundColor: `${colorTheme.accent}20`, color: colorTheme.accent }}
+                      >
+                        {drawerData.details.parameter_size}
+                      </span>
+                    )}
+                    {drawerData.details.quantization_level && (
+                      <span
+                        className="px-2 py-0.5 rounded-full text-[10px] font-semibold"
+                        style={{ backgroundColor: `${colorTheme.accent}15`, color: colorTheme.accent }}
+                      >
+                        {drawerData.details.quantization_level}
+                      </span>
+                    )}
+                    {drawerData.details.family && (
+                      <span
+                        className="px-2 py-0.5 rounded-full text-[10px] font-semibold opacity-60"
+                        style={{ backgroundColor: colorTheme.border, color: colorTheme.foreground }}
+                      >
+                        {drawerData.details.family}
+                      </span>
+                    )}
+                    {drawerData.details.format && (
+                      <span
+                        className="px-2 py-0.5 rounded-full text-[10px] font-semibold opacity-60"
+                        style={{ backgroundColor: colorTheme.border, color: colorTheme.foreground }}
+                      >
+                        {drawerData.details.format}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {drawerData.parameters && (
+                <div className="space-y-1.5">
+                  <p className="text-[10px] font-bold uppercase tracking-wider opacity-40" style={{ color: colorTheme.foreground }}>
+                    Parameters
+                  </p>
+                  <pre
+                    className="text-[10px] font-mono p-2 rounded-lg overflow-x-auto max-h-28 overflow-y-auto"
+                    style={{
+                      backgroundColor: mode === 'dark' ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.04)',
+                      color: colorTheme.foreground,
+                    }}
+                  >
+                    {drawerData.parameters}
+                  </pre>
+                </div>
+              )}
+
+              {drawerData.template && (
+                <div className="space-y-1.5">
+                  <p className="text-[10px] font-bold uppercase tracking-wider opacity-40" style={{ color: colorTheme.foreground }}>
+                    Template
+                  </p>
+                  <pre
+                    className="text-[10px] font-mono p-2 rounded-lg overflow-x-auto max-h-32 overflow-y-auto"
+                    style={{
+                      backgroundColor: mode === 'dark' ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.04)',
+                      color: colorTheme.foreground,
+                    }}
+                  >
+                    {drawerData.template}
+                  </pre>
+                </div>
+              )}
+            </>
+          ) : (
+            <p className="text-xs opacity-40 text-center pt-8" style={{ color: colorTheme.foreground }}>
+              Could not load model details.
+            </p>
+          )}
+        </div>
+
+        {/* Drawer footer — delete */}
+        {drawerModel && !drawerLoading && (
+          <div className="shrink-0 px-4 py-3 border-t" style={{ borderColor: colorTheme.border }}>
+            {deleteConfirm === drawerModel ? (
+              <div className="flex gap-2">
+                <button
+                  onClick={() => { handleDelete(drawerModel); setDrawerModel(null) }}
+                  className="flex-1 py-1.5 rounded-lg text-xs font-semibold bg-red-500/20 text-red-400 hover:bg-red-500/30 transition-colors"
+                >
+                  Confirm Delete
+                </button>
+                <button
+                  onClick={() => setDeleteConfirm(null)}
+                  className="flex-1 py-1.5 rounded-lg text-xs font-semibold opacity-50 hover:opacity-100 transition-opacity"
+                  style={{ color: colorTheme.foreground, backgroundColor: colorTheme.border }}
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => setDeleteConfirm(drawerModel)}
+                className="w-full flex items-center justify-center gap-2 py-1.5 rounded-lg text-xs font-semibold opacity-40 hover:opacity-80 transition-opacity"
+                style={{ color: colorTheme.foreground }}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Delete model
+              </button>
+            )}
           </div>
         )}
       </div>

--- a/Dashboard/Dashboard1/components/dashboard/sidebar.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/sidebar.tsx
@@ -10,6 +10,7 @@ import {
   X,
   TerminalSquare,
   Activity,
+  BrainCircuit,
   Check,
   type LucideIcon,
 } from "lucide-react"
@@ -78,11 +79,18 @@ export function Sidebar({
             onClick={() => onNavigate?.("home")}
             theme={colorTheme}
           />
-          <NavButton 
+          <NavButton
             icon={Activity}
             label="Metrics"
             active={activeSection === "metrics"}
             onClick={() => onNavigate?.("metrics")}
+            theme={colorTheme}
+          />
+          <NavButton
+            icon={BrainCircuit}
+            label="Ollama"
+            active={activeSection === "ollama"}
+            onClick={() => onNavigate?.("ollama")}
             theme={colorTheme}
           />
         </nav>

--- a/Dashboard/Dashboard1/components/dashboard/welcome-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/welcome-section.tsx
@@ -22,7 +22,8 @@ const SERVICE_PORTS = [
   { name: "Matrix", port: 8082, icon: MessageSquare },
   { name: "Vaultwarden", port: 8083, icon: Key },
   { name: "Kiwix", port: 8087, icon: Book, route: "/kiwix" },
-  { name: "Ollama", port: 8085, icon: BrainCircuit },
+  { name: "Ollama", icon: BrainCircuit, section: "ollama" },
+  { name: "Open WebUI", port: 8085, icon: MessageSquare },
   { name: "VPN Manager", port: 8090, icon: Shield },
 ]
 
@@ -77,9 +78,10 @@ export function WelcomeSection({ onNavigate }: WelcomeSectionProps) {
     () =>
       SERVICE_PORTS.map((svc) => ({
         name: svc.name,
-        url: hostname ? `http://${hostname}:${svc.port}` : "",
+        url: 'port' in svc && hostname ? `http://${hostname}:${svc.port}` : "",
         icon: svc.icon,
         route: 'route' in svc ? (svc as { route: string }).route : undefined,
+        section: 'section' in svc ? (svc as { section: string }).section : undefined,
       })),
     [hostname]
   )
@@ -141,11 +143,24 @@ export function WelcomeSection({ onNavigate }: WelcomeSectionProps) {
                       {app.name}
                     </p>
                     <p className="text-[10px] truncate uppercase tracking-widest opacity-40" style={{ color: colorTheme.foreground }}>
-                      {app.route ? "Internal" : "External"}
+                      {app.section ? "Manager" : app.route ? "Internal" : "External"}
                     </p>
                   </div>
                 </>
               )
+
+              if (app.section) {
+                return (
+                  <button
+                    key={app.name}
+                    onClick={() => onNavigate?.(app.section!)}
+                    className={cardClasses}
+                    style={cardStyle}
+                  >
+                    {cardContent}
+                  </button>
+                )
+              }
 
               if (app.route) {
                 return (

--- a/Project_S_Logs/18_Ollama_OpenWebUI_Integration.md
+++ b/Project_S_Logs/18_Ollama_OpenWebUI_Integration.md
@@ -1,79 +1,257 @@
-# Ollama + Open WebUI Integration Log (COMPLETED)
+# Ollama + Open-WebUI Integration Log
 
 ## Overview
 
-Added local LLM support to Project S via Ollama (backend) and Open WebUI (chat frontend). Also resolved several pre-existing service failures discovered during testing.
+Local LLM support added to HomeForge via two new containers: **Ollama** (model inference engine) and **Open-WebUI** (ChatGPT-style chat frontend). The dashboard includes a live Ollama section that lists pulled models and reports service health.
+
+This document covers the initial setup, the backend hardening work done in PR #99, and the model management roadmap (issue #100).
 
 ---
 
-## New Services Added
+## Services
 
 | Service | Image | Port | Purpose |
 |---------|-------|------|---------|
-| Ollama | `ollama/ollama:0.6.5` | `11434` | Local LLM inference engine |
-| Open WebUI | `ghcr.io/open-webui/open-webui:0.6.5` | `8085` | ChatGPT-like chat UI for Ollama |
+| Ollama | `ollama/ollama:0.6.5` | `11434` | LLM inference engine |
+| Open-WebUI | `ghcr.io/open-webui/open-webui:0.6.5` | `8085` | Chat UI |
 
-### Data Persistence
-- Ollama models: `./data/ollama:/root/.ollama`
-- Open WebUI data: `./data/open-webui:/app/backend/data`
-- Shared workspace: `./data/workspace:/workspace` (mounted in Ollama)
+### Data volumes
+| Path | Purpose |
+|------|---------|
+| `./data/ollama:/root/.ollama` | Model weights (persisted across restarts) |
+| `./data/open-webui:/app/backend/data` | User accounts, chat history, settings |
+| `./data/workspace:/workspace` | Shared workspace mounted in Ollama |
 
 ---
 
 ## Architecture
 
 ```
-Browser → http://localhost:8085 → Open WebUI → http://ollama:11434 → Ollama
+Browser → http://<host>:8085 → Open-WebUI (8080 internal)
+                                     ↓
+                              http://ollama:11434
+                                     ↓
+                              Ollama container
+
+Dashboard → /api/ollama (Next.js proxy)
+                ↓
+          http://ollama:11434/api/tags
 ```
 
-Open WebUI runs as a frontend only. All model inference is handled by the Ollama container. The two communicate over the internal Docker network.
+The dashboard **never** hits port 11434 directly from the browser. All Ollama API calls are proxied server-side through `/api/ollama/*`. This ensures the dashboard works regardless of how it is accessed (localhost, LAN IP, reverse proxy, domain).
 
 ---
 
-## Terminal → Theia Exec
+## Docker Compose Configuration
 
-The dashboard terminal was upgraded to exec into the Theia container instead of running a shell inside the minimal dashboard image.
+### Ollama
+```yaml
+ollama:
+  image: ollama/ollama:0.6.5
+  container_name: project-s-ollama
+  ports:
+    - '11434:11434'
+  volumes:
+    - ./data/ollama:/root/.ollama
+    - ./data/workspace:/workspace
+    - ./config/ollama:/modelfiles:ro
+  restart: unless-stopped
+  deploy:
+    resources:
+      limits:
+        memory: 4g
+  healthcheck:
+    test: ["CMD", "ollama", "list"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+    start_period: 30s
+```
 
-### How it works
-1. On each WebSocket connection, `custom-server.ts` queries the Docker socket HTTP API to check if `project-s-theia` is running
-2. If running: `docker exec -it -w /home/project/workspace project-s-theia /bin/bash`
-3. If not running: falls back to local `/bin/bash`
+### Open-WebUI
+```yaml
+open-webui:
+  image: ghcr.io/open-webui/open-webui:0.6.5
+  container_name: project-s-open-webui
+  ports:
+    - '8085:8080'
+  volumes:
+    - ./data/open-webui:/app/backend/data
+  environment:
+    - OLLAMA_BASE_URL=http://ollama:11434
+    - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY}
+    - CORS_ALLOW_ORIGIN=http://localhost:8085,http://localhost:3069,http://${HOMEFORGE_LAN_IP:-localhost}:8085,http://${HOMEFORGE_LAN_IP:-localhost}:3069
+    - WEBUI_AUTH=true
+    - JWT_EXPIRES_IN=7d
+    - ENABLE_PASSWORD_VALIDATION=true
+  depends_on:
+    ollama:
+      condition: service_healthy
+  restart: unless-stopped
+  deploy:
+    resources:
+      limits:
+        memory: 2g
+  healthcheck:
+    test: ["CMD", "curl", "-sf", "http://localhost:8080/"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+    start_period: 60s
+```
 
-### Key fixes required
-- Dashboard container must run as `root` (`user: root` in docker-compose) — the `nextjs` user cannot access `/var/run/docker.sock` on macOS due to GID mismatch
-- Docker socket must be queried via HTTP API (`http.get({ socketPath: '/var/run/docker.sock' })`) not the `docker` CLI binary
-- Terminal starts in `/home/project/workspace` — same volume mounted in Theia IDE, so files created in either terminal are immediately visible in both
+Key points:
+- `depends_on: ollama: condition: service_healthy` — Open-WebUI waits until Ollama passes its healthcheck before starting
+- `WEBUI_SECRET_KEY` must be set in `.env` — changing it invalidates all sessions
+- `CORS_ALLOW_ORIGIN` includes both localhost and LAN IP for dashboard ↔ Open-WebUI calls
+- Memory limit is 2g — first start downloads an embedding model (~400MB); 512m caused crash loops
 
 ---
 
-## Bugs Fixed During This Session
+## Dashboard Integration (PR #99)
 
-| Service | Issue | Fix |
-|---------|-------|-----|
-| Synapse (Matrix) | `postgres:16` incompatible with PG15 data | Pinned back to `postgres:15-alpine` |
-| Synapse | `homeserver.yaml` YAML parse error — password on wrong line | Fixed indentation |
-| Nextcloud | Image `nextcloud:30` but data was v33.0.1.2 | Upgraded to `nextcloud:33` |
-| Jellyfin | Missing `MaxParentalAgeRating` column in DB | Upgraded to `jellyfin/jellyfin:10.10` |
-| Nextcloud hooks | `setup-office.sh` Permission denied (exit 126) | Fixed file permissions to executable |
-| Open WebUI | Crash loop on first start | Increased memory limit from 512m → 2g (embedding model download) |
+### Problem (pre-fix)
+The dashboard's Ollama section was calling `http://${window.location.hostname}:11434` directly from the browser. This worked on `localhost` but failed on any other device on the LAN because port 11434 is only exposed on the server, not accessible cross-origin from a browser.
+
+### Fix
+Created a Next.js server-side proxy route at `app/api/ollama/route.ts`:
+
+```typescript
+const OLLAMA_BASE = process.env.OLLAMA_BASE_URL || 'http://ollama:11434'
+
+export async function GET() {
+  return new Promise<NextResponse>((resolve) => {
+    const req = httpGet(`${OLLAMA_BASE}/api/tags`, { timeout: 5000 }, (res) => {
+      let data = ''
+      res.on('data', (chunk) => { data += chunk })
+      res.on('end', () => {
+        try { resolve(NextResponse.json(JSON.parse(data))) }
+        catch { resolve(NextResponse.json({ error: 'Invalid response from Ollama' }, { status: 502 })) }
+      })
+    })
+    req.on('error', (err) => resolve(NextResponse.json({ error: err.message }, { status: 503 })))
+    req.on('timeout', () => { req.destroy(); resolve(NextResponse.json({ error: 'timed out' }, { status: 504 })) })
+  })
+}
+```
+
+The frontend component `ollama-section.tsx` now calls `fetch('/api/ollama')` with no hardcoded hostname or port.
+
+### Environment variable
+`OLLAMA_BASE_URL` can be set in the dashboard's environment block to override the default `http://ollama:11434`. This is useful if Ollama is running on a different host.
 
 ---
 
-## PRs
+## Current Dashboard Features
 
-- **#40** — Terminal Theia exec, Ollama, Kiwix ZIM listing, bug fixes (squash merged)
-- **#42** — Open WebUI (feat/open-webui branch, pending merge)
+The Ollama section (`components/dashboard/ollama-section.tsx`) provides:
+
+- **Health badge** — green/red Online/Offline status, checked on mount and on refresh
+- **Model list** — name, size (formatted GB/MB/KB), last modified date
+- **Refresh button** — manual re-fetch with spinner
+
+Data source: `GET /api/ollama` → `GET http://ollama:11434/api/tags`
+
+---
+
+## Model Management (Issue #100 — Planned)
+
+The following features are planned but not yet implemented. All require additional API proxy routes.
+
+### Available Ollama API Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/tags` | GET | List local models ✅ already proxied |
+| `/api/ps` | GET | Models currently loaded in RAM |
+| `/api/pull` | POST | Pull a model — streams NDJSON progress |
+| `/api/delete` | DELETE | Delete a local model |
+| `/api/show` | POST | Full model details (parameters, template, etc.) |
+
+### Proxy Routes to Add
+
+```
+/api/ollama/ps        → GET    http://ollama:11434/api/ps
+/api/ollama/pull      → POST   http://ollama:11434/api/pull  (streaming)
+/api/ollama/delete    → DELETE http://ollama:11434/api/delete
+/api/ollama/show      → POST   http://ollama:11434/api/show
+```
+
+### Feature Plan
+
+**1. Running state badge**
+Poll `/api/ollama/ps` every 30s. Show a "Loaded" pill on any model that is currently resident in RAM.
+
+**2. Pull a model**
+Input + Pull button in the section header. Stream the NDJSON progress response back to the browser via `ReadableStream`. Each chunk: `{ status, completed?, total?, digest? }`. Compute `completed / total * 100` for a progress bar. Disable duplicate pulls.
+
+**3. Delete a model**
+Delete icon on each model tile with a confirm dialog. DELETE to `/api/ollama/delete`. Optimistic removal with error rollback.
+
+**4. Model details drawer**
+Click a tile → slide-in drawer. Fetch from `/api/ollama/show`. Show: family, parameter count (e.g. 8B), quantization, context window, license, modelfile template.
+
+### Streaming pull implementation notes
+The Next.js route should use `TransformStream` to pipe the Ollama NDJSON stream directly to the browser response without buffering the full download:
+
+```typescript
+// rough sketch
+export async function POST(req: Request) {
+  const { name } = await req.json()
+  const { readable, writable } = new TransformStream()
+  fetch(`${OLLAMA_BASE}/api/pull`, {
+    method: 'POST',
+    body: JSON.stringify({ name, stream: true }),
+  }).then(res => res.body!.pipeTo(writable))
+  return new Response(readable, { headers: { 'Content-Type': 'application/x-ndjson' } })
+}
+```
 
 ---
 
 ## Usage
 
-### Pull and run a model
+### Pull a model (current — terminal)
 ```bash
-# From the dashboard terminal (execs into Theia):
+# From the dashboard terminal:
 docker exec project-s-ollama ollama pull llama3.2
 docker exec project-s-ollama ollama list
+docker exec project-s-ollama ollama rm llama3.2
 ```
 
 ### Chat UI
-Open `http://localhost:8085` — create an admin account on first visit, then select a model and chat.
+Open `http://<host>:8085` — create an admin account on first visit, select a model, and chat.
+
+### Recommended starter models
+
+| Model | Size | Use case |
+|-------|------|---------|
+| `llama3.2` | ~2GB | General chat, fast |
+| `llama3.2:1b` | ~1.3GB | Minimal RAM, fast responses |
+| `mistral` | ~4GB | Better reasoning |
+| `codellama` | ~4GB | Code generation |
+| `phi3` | ~2.3GB | Small, capable |
+
+---
+
+## Bugs Fixed During Integration
+
+| Service | Issue | Fix |
+|---------|-------|-----|
+| Open-WebUI | Crash loop on first start | Increased memory limit 512m → 2g (embedding model download) |
+| Open-WebUI | Sessions lost on container restart | Added `WEBUI_SECRET_KEY` to env |
+| Open-WebUI | CORS errors from dashboard | Added `CORS_ALLOW_ORIGIN` with LAN IP |
+| Open-WebUI | Started before Ollama was ready | Added `depends_on: ollama: condition: service_healthy` |
+| Dashboard | Ollama section broken on LAN access | Replaced direct port 11434 calls with `/api/ollama` proxy |
+| Ollama | Healthcheck using curl (not installed) | Switched to `ollama list` |
+
+---
+
+## Related PRs and Issues
+
+| # | Type | Title | Status |
+|---|------|-------|--------|
+| #40 | PR | Initial Ollama + Open-WebUI setup | Merged |
+| #88 | Issue | Ollama ↔ Open-WebUI unreliable connection + hardening | Closed via #99 |
+| #99 | PR | fix: Ollama integration hardening | Merged |
+| #100 | Issue | feat: Ollama model manager (pull, delete, running state) | Open |


### PR DESCRIPTION
Closes #100

## Summary
- **4 new API proxy routes** — `/api/ollama/ps` (running state), `/api/ollama/pull` (streaming NDJSON progress), `/api/ollama/delete`, `/api/ollama/show` (model details)
- **Ollama section rewrite** — pull input with real-time progress bars, "Loaded" badge for RAM-resident models, delete with inline confirm + rollback, slide-in details drawer (params, quantization, template)
- **Navigation wired** — Ollama nav button added to sidebar; `OllamaSection` mounted in `page.tsx`
- **Welcome screen** — "Ollama" card now navigates to the internal manager; "Open WebUI" added as a separate card for port 8085 chat UI
- **Docs** — `18_Ollama_OpenWebUI_Integration.md` re-optimized with full architecture, post-#99 integration state, and model management roadmap

## Test plan
- [ ] Sidebar BrainCircuit icon → navigates to Ollama section
- [ ] Welcome screen "Ollama" card → navigates to Ollama section (not port 8085)
- [ ] Welcome screen "Open WebUI" card → opens port 8085 in new tab
- [ ] Pull input: type `llama3.2`, press Enter → progress bar appears, model added to list on completion
- [ ] Click model tile → details drawer slides in with family, quantization, template
- [ ] Hover model tile → trash icon appears → click → inline Delete/Cancel confirm
- [ ] "Loaded" badge appears on any model currently in RAM (polled every 5s from `/api/ps`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)