### PR TITLE
fix: Ollama pull streaming broken — progress bar flashes and disappears

### DIFF
--- a/Dashboard/Dashboard1/app/api/ollama/pull/route.ts
+++ b/Dashboard/Dashboard1/app/api/ollama/pull/route.ts
@@ -1,51 +1,33 @@
 import { NextRequest } from 'next/server'
-import { request as httpRequest } from 'http'
 
 const OLLAMA_BASE = process.env.OLLAMA_BASE_URL || 'http://ollama:11434'
 
+/**
+ * Streaming proxy for Ollama pull — pipes NDJSON progress directly to the browser.
+ * Uses fetch() instead of Node http.request so Next.js App Router can stream
+ * the response body without buffering it.
+ */
 export async function POST(req: NextRequest) {
   const { name } = await req.json()
-  const payload = JSON.stringify({ name, stream: true })
-  const url = new URL(`${OLLAMA_BASE}/api/pull`)
 
-  const stream = new ReadableStream({
-    start(controller) {
-      const options = {
-        hostname: url.hostname,
-        port: Number(url.port) || 11434,
-        path: '/api/pull',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': Buffer.byteLength(payload),
-        },
-      }
+  let ollamaRes: Response
+  try {
+    ollamaRes = await fetch(`${OLLAMA_BASE}/api/pull`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, stream: true }),
+    })
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: String(err) }),
+      { status: 503, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
 
-      const ollamaReq = httpRequest(options, (res) => {
-        res.on('data', (chunk: Buffer) => {
-          controller.enqueue(chunk)
-        })
-        res.on('end', () => {
-          controller.close()
-        })
-        res.on('error', (err) => {
-          controller.error(err)
-        })
-      })
-
-      ollamaReq.on('error', (err) => {
-        controller.error(err)
-      })
-
-      ollamaReq.write(payload)
-      ollamaReq.end()
-    },
-  })
-
-  return new Response(stream, {
+  return new Response(ollamaRes.body, {
+    status: ollamaRes.status,
     headers: {
       'Content-Type': 'application/x-ndjson',
-      'Transfer-Encoding': 'chunked',
       'Cache-Control': 'no-cache',
     },
   })

--- a/Dashboard/Dashboard1/components/dashboard/ollama-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/ollama-section.tsx
@@ -111,20 +111,22 @@ export function OllamaSection({ isWindow }: OllamaSectionProps) {
     return () => clearInterval(id)
   }, [])
 
-  // Remove 'success' pull progress entries after 3s
+  // Remove terminal pull progress entries after a delay (success after 3s, error after 6s)
   useEffect(() => {
-    const successKeys = Object.entries(pullProgress)
-      .filter(([, v]) => v.status === 'success')
-      .map(([k]) => k)
-    if (successKeys.length === 0) return
-    const id = setTimeout(() => {
-      setPullProgress(prev => {
-        const next = { ...prev }
-        successKeys.forEach(k => delete next[k])
-        return next
-      })
-    }, 3000)
-    return () => clearTimeout(id)
+    const terminalKeys = Object.entries(pullProgress)
+      .filter(([, v]) => v.status === 'success' || v.status === 'error')
+      .map(([k, v]) => ({ k, delay: v.status === 'success' ? 3000 : 6000 }))
+    if (terminalKeys.length === 0) return
+    const timers = terminalKeys.map(({ k, delay }) =>
+      setTimeout(() => {
+        setPullProgress(prev => {
+          const next = { ...prev }
+          delete next[k]
+          return next
+        })
+      }, delay)
+    )
+    return () => timers.forEach(clearTimeout)
   }, [pullProgress])
 
   // Abort any in-progress pull on unmount
@@ -156,6 +158,7 @@ export function OllamaSection({ isWindow }: OllamaSectionProps) {
       const reader = res.body.getReader()
       const decoder = new TextDecoder()
       let buffer = ''
+      let hadError = false
 
       while (true) {
         const { done, value } = await reader.read()
@@ -170,26 +173,25 @@ export function OllamaSection({ isWindow }: OllamaSectionProps) {
             const msg = JSON.parse(line)
             const total = msg.total ?? 0
             const completed = msg.completed ?? 0
+            // Treat Ollama-level errors (returned in the NDJSON) as failures
+            const status = msg.error ? 'error' : (msg.status ?? 'pulling')
+            if (status === 'error') hadError = true
             setPullProgress(prev => ({
               ...prev,
-              [name]: {
-                status: msg.status ?? 'pulling',
-                total,
-                completed,
-                percent: total > 0 ? Math.round((completed / total) * 100) : 0,
-                error: msg.error,
-              },
+              [name]: { status, total, completed, percent: total > 0 ? Math.round((completed / total) * 100) : 0, error: msg.error },
             }))
           } catch { /* malformed NDJSON chunk, skip */ }
         }
       }
 
-      await fetchModels()
-      setPullInput('')
-      setPullProgress(prev => ({
-        ...prev,
-        [name]: { status: 'success', total: 1, completed: 1, percent: 100 },
-      }))
+      if (!hadError) {
+        await fetchModels()
+        setPullInput('')
+        setPullProgress(prev => ({
+          ...prev,
+          [name]: { status: 'success', total: 1, completed: 1, percent: 100 },
+        }))
+      }
     } catch (e: unknown) {
       if (e instanceof Error && e.name === 'AbortError') return
       setPullProgress(prev => ({


### PR DESCRIPTION
Closes #102

## Root Causes Fixed

### 1. Pull route — wrong streaming approach
`ReadableStream` + Node `http.request` does not stream in Next.js App Router standalone mode. Next.js buffers or closes the connection before any data arrives, causing the progress bar to flash and immediately disappear.

**Fix:** Replaced with `fetch()` which returns a native streaming `Response`. Its `.body` is piped directly to the browser — zero buffering.

### 2. Frontend — Ollama error lines treated as success
When Ollama returns `{"error":"pull model manifest: file does not exist"}`, `msg.status` is undefined so the code fell back to `status: 'pulling'`. After the stream closed, the pull was marked `'success'` and cleaned up after 3s, giving the appearance of a silent no-op.

**Fix:** Check `msg.error` first and set `status: 'error'`. Track a `hadError` flag to skip the success path when the stream ends with an error.

**Bonus:** Error progress entries now auto-clear after 6s (success stays at 3s).

## Test plan
- [ ] Run `./boom.sh` to rebuild
- [ ] Type `llama3.2` in the pull input → progress bar persists and shows % as bytes download
- [ ] Type a non-existent model name → progress bar shows red "Error" state for 6s then clears
- [ ] Model appears in list after successful pull

🤖 Generated with [Claude Code](https://claude.com/claude-code)