### PR TITLE
chore: bump Ollama to 0.20.0 and Open-WebUI to 0.8.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -229,7 +229,7 @@ services:
       start_period: 15s
 
   open-webui:
-    image: ghcr.io/open-webui/open-webui:0.6.5
+    image: ghcr.io/open-webui/open-webui:0.8.6
     container_name: project-s-open-webui
     ports:
       - '8085:8080'
@@ -258,7 +258,7 @@ services:
       start_period: 60s
 
   ollama:
-    image: ollama/ollama:0.6.5
+    image: ollama/ollama:0.20.0
     container_name: project-s-ollama
     ports:
       - '11434:11434'


### PR DESCRIPTION
Closes #104

## Problem
Ollama `0.6.5` is too old to pull Qwen3 and other recent models:
```
Error: pull model manifest: 412:
The model you are attempting to pull requires a newer version of Ollama.
```

## Changes
| Service | Before | After |
|---|---|---|
| `ollama/ollama` | `0.6.5` | `0.20.0` |
| `ghcr.io/open-webui/open-webui` | `0.6.5` | `0.8.6` |

## Notes
- Data volumes (`./data/ollama`, `./data/open-webui`) are persisted — existing pulled models and Open-WebUI user accounts survive the upgrade
- `boom.sh` will pull the new images automatically on next run

## Test plan
- [ ] Run `./boom.sh`
- [ ] Pull `qwen3:0.6b` from the Ollama manager — should download successfully
- [ ] Open-WebUI at port 8085 — existing account should still be accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)