### PR TITLE
fix: bump Open-WebUI to 0.8.12 — streaming JSON parse error with Ollama 0.20.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -229,7 +229,7 @@ services:
       start_period: 15s
 
   open-webui:
-    image: ghcr.io/open-webui/open-webui:0.8.6
+    image: ghcr.io/open-webui/open-webui:0.8.12
     container_name: project-s-open-webui
     ports:
       - '8085:8080'


### PR DESCRIPTION
## Problem

Open-WebUI 0.8.6 throws the following error when chatting with any model:
```
Unexpected token 'd', "data: {"id"... is not valid JSON
```

This affects all models (llama3.2, qwen3, etc.). Root cause: 0.8.6 has a streaming format incompatibility with Ollama 0.20.0 — it receives SSE-formatted responses (`data: {...}`) but tries to parse them as plain JSON.

Open-WebUI itself surfaces the fix: the in-app update banner shows **v0.8.12 is available**.

## Change
`ghcr.io/open-webui/open-webui:0.8.6` → `ghcr.io/open-webui/open-webui:0.8.12`

User data in `./data/open-webui` is persisted — accounts and chat history survive the upgrade.

## Test plan
- [ ] Merge and run `./boom.sh`
- [ ] Open WebUI at port 8085
- [ ] Send a message with `llama3.2:latest` — should respond without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)