### PR TITLE
fix: disable Open-WebUI WebSocket to resolve chat JSON parse error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -242,6 +242,7 @@ services:
       - WEBUI_AUTH=true
       - JWT_EXPIRES_IN=7d
       - ENABLE_PASSWORD_VALIDATION=true
+      - ENABLE_WEBSOCKET_SUPPORT=false
     depends_on:
       ollama:
         condition: service_healthy


### PR DESCRIPTION
## Problem

Open-WebUI 0.8.x uses Socket.IO (WebSocket) to stream chat responses. In direct Docker port-mapping setups (no reverse proxy), WebSocket connections to `ws://localhost:8085/ws/socket.io/` fail repeatedly. Open-WebUI then delivers the chat response via HTTP fallback in SSE format (`data: {...}`), but the frontend code tries to `JSON.parse()` it directly, throwing:

```
Unexpected token 'd', "data: {"id"... is not valid JSON
```

## Fix

Add `ENABLE_WEBSOCKET_SUPPORT=false` to Open-WebUI's environment. This forces HTTP polling which works reliably through Docker's port mapping without a reverse proxy.

## Test plan
- [ ] Merge and `./boom.sh`
- [ ] Hard-refresh browser (`Cmd+Shift+Delete` → clear cache) at `localhost:8085`
- [ ] Send a chat message with any model — should respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)