### PR TITLE
feat: unified terminal — bridge Theia shell into dashboard container (#110)

### DIFF
--- a/Dashboard/Dashboard1/custom-server.ts
+++ b/Dashboard/Dashboard1/custom-server.ts
@@ -77,7 +77,7 @@ wss.on('connection', async (ws: WebSocket, req: IncomingMessage) => {
       name: 'xterm-256color',
       cols: 80,
       rows: 24,
-      cwd: process.env.HOME || '/root',
+      cwd: '/homelab',
       env: { ...process.env, TERM: 'xterm-256color' } as Record<string, string>,
     })
   } catch (err) {

--- a/config/terminal/homelab-shell
+++ b/config/terminal/homelab-shell
@@ -1,0 +1,10 @@
+#!/bin/sh
+# HomeForge unified shell — bridges Theia terminal into the dashboard container
+# so both Theia and the dashboard share one environment.
+# Falls back to local bash if the dashboard container is unavailable.
+if docker exec -it project-s-dashboard /bin/bash "$@" 2>/dev/null; then
+  exit $?
+else
+  echo "[dashboard unavailable — running local shell]"
+  exec /bin/bash "$@"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,8 @@ services:
       - '3070:3070'
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./data:/data:ro
+      - ./data:/data
+      - .:/homelab
     environment:
       - PORT=3069
       - WS_PORT=3070
@@ -152,8 +153,10 @@ services:
     volumes:
       - ./data/workspace:/home/project/workspace
       - /var/run/docker.sock:/var/run/docker.sock
+      - .:/homelab
+      - ./config/terminal/homelab-shell:/usr/local/bin/homelab-shell:ro
     environment:
-      - SHELL=/bin/bash
+      - SHELL=/usr/local/bin/homelab-shell
     restart: 'unless-stopped'
     deploy:
       resources:


### PR DESCRIPTION
## Summary
- Adds `config/terminal/homelab-shell` wrapper script that `docker exec`s into `project-s-dashboard` when a terminal is opened in Theia
- Mounts script into Theia container and sets it as `SHELL`
- Falls back to local bash with a clear message if dashboard is unavailable
- Removes `:ro` from dashboard data volume — full write access
- Default shell cwd set to `/homelab` in `custom-server.ts`

Both terminals now share one environment — same hostname, same files, same tools.

Closes #110

## Test plan
- [ ] `docker compose up -d --build theia`
- [ ] Open terminal in Theia — should show `project-s-dashboard` hostname
- [ ] Create a file in Theia terminal, confirm it appears in dashboard terminal
- [ ] Stop dashboard container, confirm Theia terminal falls back gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)