### PR TITLE
fix: Open-WebUI & Ollama stability (WebSocket 400s & Model Swap hangs)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -241,11 +241,13 @@ services:
     environment:
       - OLLAMA_BASE_URL=http://ollama:11434
       - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY}
-      - CORS_ALLOW_ORIGIN=http://localhost:8085,http://localhost:3069,http://${HOMEFORGE_LAN_IP:-localhost}:8085,http://${HOMEFORGE_LAN_IP:-localhost}:3069
+      - CORS_ALLOW_ORIGIN=*
       - WEBUI_AUTH=true
       - JWT_EXPIRES_IN=7d
       - ENABLE_PASSWORD_VALIDATION=true
-      - ENABLE_WEBSOCKET_SUPPORT=false
+      - ENABLE_WEBSOCKET_SUPPORT=true
+      - WEBUI_URL=http://${HOMEFORGE_LAN_IP:-localhost}:8085
+      - WEBUI_NAME=HomeForge AI
     depends_on:
       ollama:
         condition: service_healthy
@@ -270,11 +272,14 @@ services:
       - ./data/ollama:/root/.ollama
       - ./data/workspace:/workspace
       - ./config/ollama:/modelfiles:ro
+    environment:
+      - OLLAMA_MAX_LOADED_MODELS=1
+      - OLLAMA_KEEP_ALIVE=5m
     restart: unless-stopped
     deploy:
       resources:
         limits:
-          memory: 4g
+          memory: 8g
     healthcheck:
       test: ["CMD", "ollama", "list"]
       interval: 30s


### PR DESCRIPTION
This PR fixes several stability issues in the Open-WebUI and Ollama stack:

1. **WebSocket Enabling:** Re-enabled WebSockets for Open-WebUI. This resolves the `400 Bad Request` errors encountered when using HTTP polling over Cloudflare tunnels (session ID mismatches).
2. **CORS Broadening:** Set `CORS_ALLOW_ORIGIN=*` to prevent origin rejection when accessed via different hostnames/proxies.
3. **Memory Hardening:** Increased Ollama memory limit to **8GB** to provide sufficient overhead during model transitions.
4. **Swap Optimization:** Added `OLLAMA_MAX_LOADED_MODELS=1` to prevent runner conflicts during swaps and `OLLAMA_KEEP_ALIVE=5m` to flush RAM after use.

Tested and verified stable on host.