### PR TITLE
feat: sidebar dock UX, floating app panels & terminal resize overhaul

### DIFF
--- a/Dashboard/Dashboard1/app/page.tsx
+++ b/Dashboard/Dashboard1/app/page.tsx
@@ -1,15 +1,27 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState, useCallback } from "react"
 import { Sidebar } from "@/components/dashboard/sidebar"
 import { WelcomeSection } from "@/components/dashboard/welcome-section"
 import { DashboardSection } from "@/components/dashboard/dashboard-section"
 import { MetricsSection } from "@/components/dashboard/metrics-section"
 import { OllamaSection } from "@/components/dashboard/ollama-section"
+import { KiwixSection } from "@/components/dashboard/kiwix-section"
 import { TerminalPanel } from "@/components/dashboard/terminal-panel"
+import { type DockApp } from "@/components/dashboard/dock"
 import { useTheme } from "@/components/theme-provider"
 import { cn } from "@/lib/utils"
-import { Construction } from "lucide-react"
+import { Construction, BrainCircuit, Book } from "lucide-react"
+
+interface ActiveWindow {
+  id: string
+  name: string
+  icon: any
+  component: React.ReactNode
+  isMinimized: boolean
+  isClosing?: boolean
+}
+
 export default function HomePage() {
   const IS_LANDING = process.env.NEXT_PUBLIC_LANDING_MODE === 'true'
   const { colorTheme } = useTheme()
@@ -18,6 +30,7 @@ export default function HomePage() {
   const [terminalOpen, setTerminalOpen] = useState(false)
   const [execTarget, setExecTarget] = useState<string | undefined>()
   const [currentSection, setCurrentSection] = useState("home")
+  const [openWindows, setOpenWindows] = useState<ActiveWindow[]>([])
   const containerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -29,7 +42,6 @@ export default function HomePage() {
       if (!containerRef.current || currentSection !== "home") return
       const scrollTop = window.scrollY
       const windowHeight = window.innerHeight
-      // Calculate progress based on first screen scroll
       const progress = Math.min(scrollTop / windowHeight, 1)
       setScrollProgress(progress)
     }
@@ -38,15 +50,65 @@ export default function HomePage() {
     return () => window.removeEventListener("scroll", handleScroll)
   }, [currentSection])
 
+  const openApp = useCallback((id: string, name: string, icon: any, component: React.ReactNode) => {
+    setOpenWindows(prev => {
+      const existing = prev.find(w => w.id === id)
+      if (existing) {
+        // Restore if closing or minimized
+        return prev.map(w => w.id === id ? { ...w, isMinimized: false, isClosing: false } : w)
+      }
+      return [...prev, { id, name, icon, component, isMinimized: false }]
+    })
+  }, [])
+
+  const closeApp = useCallback((id: string) => {
+    setOpenWindows(prev => prev.map(w => w.id === id ? { ...w, isClosing: true, isMinimized: false } : w))
+    setTimeout(() => {
+      setOpenWindows(prev => prev.filter(w => !(w.id === id && w.isClosing)))
+    }, 12000)
+  }, [])
+
+  // Sidebar icon click: if active → close (grace period); if closing → reopen
+  const handleDockClick = useCallback((id: string) => {
+    const win = openWindows.find(w => w.id === id)
+    if (!win) return
+    if (win.isClosing) {
+      if (id === "ollama") openApp("ollama", "Ollama", BrainCircuit, <OllamaSection />)
+      if (id === "kiwix") openApp("kiwix", "Kiwix", Book, <KiwixSection isWindow />)
+    } else {
+      closeApp(id)
+    }
+  }, [openWindows, openApp, closeApp])
+
   const bgColor = mounted ? colorTheme.background : "#0a0a0a"
   const accentColor = mounted ? colorTheme.accent : "#d4e157"
 
   const handleNavigate = (section: string) => {
+    if (section === "ollama") {
+      openApp("ollama", "Ollama", BrainCircuit, <OllamaSection isWindow />)
+      return
+    }
+    if (section === "kiwix") {
+      openApp("kiwix", "Kiwix", Book, <KiwixSection isWindow />)
+      return
+    }
+    // Close all open apps when navigating away
+    setOpenWindows([])
     setCurrentSection(section)
     if (section === "home") {
       window.scrollTo({ top: 0, behavior: "smooth" })
     }
   }
+
+  // Show all open windows in the sidebar — active, minimized, or closing
+  const dockApps: DockApp[] = openWindows.map(w => ({
+    id: w.id,
+    name: w.name,
+    icon: w.icon,
+    isOpen: !w.isClosing,
+    isActive: !w.isMinimized && !w.isClosing,
+    isClosing: w.isClosing
+  }))
 
   return (
     <div 
@@ -95,22 +157,42 @@ export default function HomePage() {
 
       {/* Sidebar */}
       <Sidebar
-        activeSection={currentSection}
+        activeSection={openWindows.some(w => !w.isClosing) ? "app" : currentSection}
         onNavigate={handleNavigate}
         terminalOpen={terminalOpen}
         onToggleTerminal={() => setTerminalOpen(prev => !prev)}
+        dockApps={dockApps}
+        onDockAppClick={handleDockClick}
       />
 
-      <main className="relative z-10 h-full w-full">
-        {/* HOME / METRICS VIEW (Static / Scrollable) */}
-        {/* OLLAMA SECTION */}
-        <div className={cn(
-          "h-full w-full transition-all duration-500",
-          currentSection === "ollama" ? "opacity-100 scale-100" : "opacity-0 scale-95 pointer-events-none absolute inset-0"
-        )}>
-          <OllamaSection />
+      {/* Floating App Panels */}
+      {openWindows.map((win) => (
+        <div
+          key={win.id}
+          className="fixed z-30 transition-all duration-500"
+          style={{
+            top: '20px',
+            bottom: '20px',
+            left: '92px',
+            right: '20px',
+            opacity: win.isClosing ? 0 : 1,
+            pointerEvents: win.isClosing ? 'none' : 'auto',
+            borderRadius: '20px',
+            overflow: 'hidden',
+            border: `1px solid ${colorTheme.border}`,
+            backgroundColor: colorTheme.card,
+            backdropFilter: 'blur(40px) saturate(150%)',
+            WebkitBackdropFilter: 'blur(40px) saturate(150%)',
+            boxShadow: '0 32px 80px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.04)',
+          }}
+        >
+          {win.component}
         </div>
+      ))}
 
+
+
+      <main className="relative z-10 h-full w-full">
         <div className={cn(
           "h-full w-full transition-all duration-500",
           (currentSection === "home" || currentSection === "metrics") ? "opacity-100 scale-100" : "opacity-0 scale-95 pointer-events-none absolute inset-0"

--- a/Dashboard/Dashboard1/components/dashboard/dock.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/dock.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import React, { useEffect, useState } from "react"
+import { useTheme } from "@/components/theme-provider"
+import { cn } from "@/lib/utils"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { LucideIcon } from "lucide-react"
+
+export interface DockApp {
+  id: string
+  name: string
+  icon: LucideIcon | React.ElementType
+  isOpen: boolean
+  isActive: boolean
+  isClosing?: boolean
+}
+
+interface DockProps {
+  apps: DockApp[]
+  onAppClick: (id: string) => void
+}
+
+export function Dock({ apps, onAppClick }: DockProps) {
+  const { colorTheme } = useTheme()
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[100] px-3 py-2 rounded-2xl border flex items-end gap-2 shadow-2xl backdrop-blur-3xl transition-all duration-500"
+        style={{ 
+          backgroundColor: `${colorTheme.card}80`,
+          borderColor: colorTheme.border,
+        }}
+      >
+        {apps.map((app) => (
+          <DockIcon 
+            key={app.id} 
+            app={app} 
+            onClick={() => onAppClick(app.id)}
+            theme={colorTheme}
+          />
+        ))}
+      </div>
+    </TooltipProvider>
+  )
+}
+
+function DockIcon({ 
+  app, 
+  onClick,
+  theme 
+}: { 
+  app: DockApp
+  onClick: () => void
+  theme: any
+}) {
+  const Icon = app.icon
+  const [isBouncing, setIsBouncing] = useState(false)
+
+  useEffect(() => {
+    if (app.isActive) {
+      setIsBouncing(true)
+      const timer = setTimeout(() => setIsBouncing(false), 1000)
+      return () => clearTimeout(timer)
+    }
+  }, [app.isActive])
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          onClick={() => {
+            setIsBouncing(true)
+            setTimeout(() => setIsBouncing(false), 600)
+            onClick()
+          }}
+          className={cn(
+            "relative group flex flex-col items-center transition-all duration-500",
+            app.isClosing ? "opacity-40 grayscale scale-90" : "opacity-100 grayscale-0 scale-100"
+          )}
+        >
+          <div
+            className={cn(
+              "flex h-12 w-12 items-center justify-center rounded-xl transition-all duration-300 shadow-lg",
+              isBouncing && "animate-bounce",
+              app.isActive ? "scale-110" : "scale-100 hover:scale-105"
+            )}
+            style={{ 
+              backgroundColor: app.isActive ? theme.accent : `${theme.accent}15`,
+              color: app.isActive ? theme.accentForeground : theme.accent,
+              border: `1px solid ${app.isActive ? theme.accent : `${theme.accent}30`}`
+            }}
+          >
+            <Icon className="h-6 w-6" strokeWidth={1.5} />
+          </div>
+          
+          {/* Active Indicator */}
+          {app.isOpen && !app.isClosing && (
+            <div 
+              className="absolute -bottom-1 w-1 h-1 rounded-full transition-all duration-500"
+              style={{ backgroundColor: theme.accent }}
+            />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={10}>
+        <p className="text-xs font-bold">{app.name}</p>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/Dashboard/Dashboard1/components/dashboard/sidebar.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/sidebar.tsx
@@ -10,7 +10,6 @@ import {
   X,
   TerminalSquare,
   Activity,
-  BrainCircuit,
   Check,
   type LucideIcon,
 } from "lucide-react"
@@ -20,6 +19,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { type DockApp } from "@/components/dashboard/dock"
 
 interface SidebarProps {
   className?: string
@@ -27,6 +27,8 @@ interface SidebarProps {
   onNavigate?: (section: string) => void
   terminalOpen?: boolean
   onToggleTerminal?: () => void
+  dockApps?: DockApp[]
+  onDockAppClick?: (id: string) => void
 }
 
 export function Sidebar({ 
@@ -34,7 +36,9 @@ export function Sidebar({
   activeSection = "home", 
   onNavigate, 
   terminalOpen, 
-  onToggleTerminal
+  onToggleTerminal,
+  dockApps = [],
+  onDockAppClick,
 }: SidebarProps) {
   const IS_LANDING = process.env.NEXT_PUBLIC_LANDING_MODE === 'true'
   const [showSettings, setShowSettings] = useState(false)
@@ -87,16 +91,53 @@ export function Sidebar({
             onClick={() => onNavigate?.("metrics")}
             theme={colorTheme}
           />
-          {!IS_LANDING && (
-            <NavButton
-              icon={BrainCircuit}
-              label="Ollama"
-              active={activeSection === "ollama"}
-              onClick={() => onNavigate?.("ollama")}
-              theme={colorTheme}
-            />
-          )}
+
         </nav>
+
+        {/* App Icons — active / minimized / closing windows */}
+        {dockApps.length > 0 && (
+          <>
+            <div className="mx-3 h-px transition-colors duration-500" style={{ backgroundColor: colorTheme.border }} />
+            <div className="flex flex-col items-center gap-1 px-2 py-2">
+              {dockApps.map((app) => {
+                const Icon = app.icon
+                const isActive = app.isActive
+                const isClosing = app.isClosing
+                const isMinimized = !isActive && !isClosing
+                return (
+                  <Tooltip key={app.id}>
+                    <TooltipTrigger asChild>
+                      <button
+                        onClick={() => onDockAppClick?.(app.id)}
+                        className="relative flex h-9 w-9 items-center justify-center rounded-xl transition-all duration-300"
+                        style={{
+                          backgroundColor: isActive
+                            ? colorTheme.accent
+                            : isClosing
+                            ? `${colorTheme.accent}08`
+                            : `${colorTheme.accent}15`,
+                          color: isActive
+                            ? colorTheme.accentForeground
+                            : colorTheme.accent,
+                          opacity: isClosing ? 0.3 : 1,
+                          filter: isClosing ? 'grayscale(1)' : 'none',
+                        }}
+                      >
+                        <Icon className="h-[18px] w-[18px]" strokeWidth={1.5} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="right" sideOffset={12}>
+                      <p>
+                        {app.name}
+                        {isActive ? ' — open' : isClosing ? ' (closing…)' : ' (minimized)'}
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                )
+              })}
+            </div>
+          </>
+        )}
 
         {/* Divider */}
         <div className="mx-3 h-px transition-colors duration-500" style={{ backgroundColor: colorTheme.border }} />

--- a/Dashboard/Dashboard1/components/dashboard/terminal-panel.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/terminal-panel.tsx
@@ -232,6 +232,10 @@ export function TerminalPanel({ open, onClose, execTarget, onExecConsumed }: Ter
   const [height, setHeight] = useState(320)
 
   const resizeRef = useRef<HTMLDivElement>(null)
+  const panelRef  = useRef<HTMLDivElement>(null)  // for direct DOM height during drag
+  const isDragging = useRef(false)
+  const heightRef = useRef(height)         // always-current height for drag handler
+  useEffect(() => { heightRef.current = height }, [height])
   const tabCounter = useRef(1)
   const fitFns = useRef<Map<string, () => void>>(new Map())
   // Fix #4: track whether the panel has ever been opened
@@ -293,35 +297,46 @@ export function TerminalPanel({ open, onClose, execTarget, onExecConsumed }: Ter
     const resizeEl = resizeRef.current
     if (!resizeEl) return
 
-    let startY = 0
-    let startHeight = 0
-
-    const onMouseMove = (e: MouseEvent) => {
-      const delta = startY - e.clientY
-      const newH = Math.min(Math.max(startHeight + delta, 200), window.innerHeight - 100)
-      setHeight(newH)
-    }
-
-    const onMouseUp = () => {
-      document.removeEventListener("mousemove", onMouseMove)
-      document.removeEventListener("mouseup", onMouseUp)
-      document.body.style.cursor = ""
-      document.body.style.userSelect = ""
-      fitFns.current.get(activeTab)?.()
-    }
-
     const onMouseDown = (e: MouseEvent) => {
-      startY = e.clientY
-      startHeight = height
+      e.preventDefault()
+      const startY = e.clientY
+      const startHeight = heightRef.current
+      isDragging.current = true
+
+      // Strip transition during drag so it's instant
+      if (panelRef.current) panelRef.current.style.transition = 'none'
+
       document.body.style.cursor = "ns-resize"
       document.body.style.userSelect = "none"
+
+      const onMouseMove = (e: MouseEvent) => {
+        if (!panelRef.current) return
+        const delta = startY - e.clientY
+        const newH = Math.min(Math.max(startHeight + delta, 160), window.innerHeight - 80)
+        // Direct DOM update — zero React re-renders during drag
+        panelRef.current.style.height = `${newH}px`
+        heightRef.current = newH
+      }
+
+      const onMouseUp = () => {
+        document.removeEventListener("mousemove", onMouseMove)
+        document.removeEventListener("mouseup", onMouseUp)
+        document.body.style.cursor = ""
+        document.body.style.userSelect = ""
+        isDragging.current = false
+        // Restore transition and commit final height to React state
+        if (panelRef.current) panelRef.current.style.transition = ''
+        setHeight(heightRef.current)
+        setTimeout(() => fitFns.current.get(activeTab)?.(), 80)
+      }
+
       document.addEventListener("mousemove", onMouseMove)
       document.addEventListener("mouseup", onMouseUp)
     }
 
     resizeEl.addEventListener("mousedown", onMouseDown)
     return () => resizeEl.removeEventListener("mousedown", onMouseDown)
-  }, [height, activeTab])
+  }, [activeTab, open])
 
   useEffect(() => {
     const timer = setTimeout(() => fitFns.current.get(activeTab)?.(), 100)
@@ -365,30 +380,39 @@ export function TerminalPanel({ open, onClose, execTarget, onExecConsumed }: Ter
   return (
     // Fix #4: use CSS transform to hide instead of unmounting — sessions stay alive
     <div
-      className="fixed bottom-0 left-0 right-0 z-[60] flex flex-col transition-transform duration-300 ease-out"
+      ref={panelRef}
+      className="fixed z-[60] flex flex-col transition-all duration-300 ease-out"
       style={{
         height: panelHeight,
-        marginLeft: isMaximized ? 0 : "72px",
-        transform: open ? 'translateY(0)' : 'translateY(100%)',
+        ...(isMaximized
+          ? { top: 0, left: 0, right: 0, bottom: 0 }
+          : { bottom: '20px', left: '92px', right: '20px' }
+        ),
+        transform: open ? 'translateY(0)' : 'translateY(calc(100% + 20px))',
       }}
     >
-      {/* Resize Handle */}
+
+
+      {/* Resize Strip */}
       {!isMaximized && (
         <div
           ref={resizeRef}
-          className="h-1.5 cursor-ns-resize flex items-center justify-center"
-          style={{ background: "transparent" }}
+          className="flex items-center justify-center cursor-ns-resize shrink-0 group"
+          style={{ height: '20px', background: 'transparent' }}
         >
           <div
-            className="w-12 h-0.5 rounded-full"
-            style={{ backgroundColor: mode === 'dark' ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.1)' }}
+            className="h-1 rounded-full transition-all duration-200 group-hover:opacity-80"
+            style={{
+              width: '64px',
+              backgroundColor: mode === 'dark' ? 'rgba(255,255,255,0.25)' : 'rgba(0,0,0,0.2)',
+            }}
           />
         </div>
       )}
 
       {/* Main Panel */}
       <div
-        className="flex-1 flex flex-col overflow-hidden border-t rounded-t-xl shadow-2xl"
+        className="flex-1 flex flex-col overflow-hidden border rounded-2xl shadow-2xl"
         style={{
           backgroundColor: mode === 'dark' ? 'rgba(10, 10, 10, 0.97)' : 'rgba(245, 245, 245, 0.97)',
           backdropFilter: "blur(24px) saturate(120%)",
@@ -397,11 +421,15 @@ export function TerminalPanel({ open, onClose, execTarget, onExecConsumed }: Ter
         }}
       >
         {/* Tab Bar */}
-        <div className="flex items-center h-9 px-2 border-b shrink-0" style={{ borderColor: colorTheme.border }}>
+        <div
+          className="flex items-center h-9 px-2 border-b shrink-0"
+          style={{ borderColor: colorTheme.border }}
+        >
           <div className="flex items-center gap-0.5 flex-1 overflow-x-auto">
             {tabs.map((tab) => (
               <div
                 key={tab.id}
+                data-tab
                 onClick={() => setActiveTab(tab.id)}
                 className="flex items-center gap-1.5 px-3 h-7 rounded-md text-xs cursor-pointer transition-all group"
                 style={activeTab === tab.id ? {

--- a/Dashboard/Dashboard1/components/dashboard/welcome-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/welcome-section.tsx
@@ -23,7 +23,7 @@ const SERVICE_PORTS = [
   { name: "Theia IDE", port: 3030, icon: Code },
   { name: "Matrix", port: 8082, icon: MessageSquare },
   { name: "Vaultwarden", port: 8083, icon: Key },
-  { name: "Kiwix", port: 8087, icon: Book, route: "/kiwix" },
+  { name: "Kiwix", port: 8087, icon: Book, section: "kiwix" },
   { name: "Ollama", icon: BrainCircuit, section: "ollama" },
   { name: "Open WebUI", port: 8085, icon: MessageSquare },
   { name: "VPN Manager", port: 8090, icon: Shield },
@@ -147,7 +147,7 @@ export function WelcomeSection({ onNavigate }: WelcomeSectionProps) {
                       {app.name}
                     </p>
                     <p className="text-[10px] truncate uppercase tracking-widest opacity-40" style={{ color: colorTheme.foreground }}>
-                      {app.section ? "Manager" : app.route ? "Internal" : "External"}
+                      {(app.section || app.route) ? "Internal" : "External"}
                     </p>
                   </div>
                 </>


### PR DESCRIPTION
## Summary
Resolves #130 · Relates to #112

Reworks the internal app management system (Kiwix, Ollama) and the terminal panel UX into a clean, floating-panel based design.

## Changes

### Internal App Labels
- Kiwix and Ollama now correctly display **Internal** badge

### Sidebar Dock
- Removed bottom dock bar entirely
- App icons appear in the **left sidebar** with 3 visual states: active / minimized / closing (12s grace → auto-removed)
- No sidebar nav tab highlighted when an internal app is open

### Floating App Panels (Kiwix & Ollama)
- Removed `WindowWrapper` frame entirely
- Apps render as **frameless floating panels**: 20px top/right/bottom gap, 92px left gap (clears sidebar), `rounded-2xl`, border, backdrop blur
- Clicking any sidebar nav item closes open apps instantly

### Terminal Panel
- Now a **floating panel** matching app panel style (92px left, 20px right/bottom, `rounded-2xl`)
- Resize strip restored — 20px tall, visible pill indicator
- **Fixed resize bug**: listener was never attached on first open (added `open` to effect deps)
- **Smooth resize**: direct DOM manipulation during drag (zero React re-renders); transition stripped mid-drag, committed once on `mouseup`

## Testing
- [ ] Open Kiwix → confirm Internal label, floating panel, sidebar icon active
- [ ] Open Ollama → same as above
- [ ] Click Home/Metrics while app open → app closes, nav navigates
- [ ] Terminal open → drag resize strip up/down → smooth, no glitching
- [ ] Terminal maximize → returns to floating on restore