### PR TITLE
feat: Phase 3 — TIER 2 SQLite-persisted time-series charts

### DIFF
--- a/Dashboard/Dashboard1/app/api/stats/history/route.ts
+++ b/Dashboard/Dashboard1/app/api/stats/history/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server'
+import { requireSession } from '@/lib/auth'
+import { getDb } from '@/lib/db'
+
+export async function GET() {
+  await requireSession()
+  try {
+    const db = getDb()
+
+    // Auto-cleanup old entries
+    db.exec('DELETE FROM metrics_history WHERE created_at < unixepoch() - 86400')
+
+    // Fetch last 120 readings (~1h at 30s intervals)
+    const rows = db.prepare(
+      'SELECT created_at, cpu, memory, gpu, disk, net_down, net_up FROM metrics_history ORDER BY id DESC LIMIT 120'
+    ).all() as Array<{
+      created_at: number
+      cpu: number | null
+      memory: number | null
+      gpu: number | null
+      disk: number | null
+      net_down: number | null
+      net_up: number | null
+    }>
+
+    // Convert to time-series format for charts
+    const history = rows.reverse().map(r => ({
+      time: new Date(r.created_at * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }),
+      cpu: r.cpu ?? 0,
+      memory: r.memory ?? 0,
+      gpu: r.gpu ?? 0,
+      disk: r.disk ?? 0,
+      netDown: r.net_down ? (r.net_down / (1024 * 1024)).toFixed(1) : '0',
+      netUp: r.net_up ? (r.net_up / (1024 * 1024)).toFixed(1) : '0',
+    }))
+
+    return NextResponse.json(history)
+  } catch (error) {
+    console.error('History API Error:', error)
+    return NextResponse.json({ error: 'Failed to fetch history' }, { status: 500 })
+  }
+}

--- a/Dashboard/Dashboard1/app/api/stats/route.ts
+++ b/Dashboard/Dashboard1/app/api/stats/route.ts
@@ -4,6 +4,7 @@ import { promisify } from 'util'
 import fs from 'fs'
 import path from 'path'
 import { requireSession } from '@/lib/auth'
+import { getDb } from '@/lib/db'
 
 const execAsync = promisify(exec)
 
@@ -223,6 +224,24 @@ export async function GET() {
       temps,
       diskUsedPerc: diskPerc,
       uptimeDays,
+    }
+
+    // Write to SQLite history (every poll)
+    try {
+      const db = getDb()
+      db.exec('DELETE FROM metrics_history WHERE created_at < unixepoch() - 86400') // TTL 24h
+      db.prepare(
+        'INSERT INTO metrics_history (cpu, memory, gpu, disk, net_down, net_up) VALUES (?, ?, ?, ?, ?, ?)'
+      ).run(
+        cpuVal,
+        memPercVal,
+        gpuData?.load ?? 0,
+        diskPerc ?? 0,
+        totalNetIO.down,
+        totalNetIO.up,
+      )
+    } catch (err) {
+      console.error('Failed to write metrics history:', err)
     }
 
     return NextResponse.json(result)

--- a/Dashboard/Dashboard1/components/dashboard/metrics-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/metrics-section.tsx
@@ -59,6 +59,29 @@ export function MetricsSection() {
   const [networkHistory, setNetworkHistory] = useState<NetworkHistoryPoint[]>([])
   const isFetching = useRef(false)
 
+  // Fetch persisted history on mount
+  useEffect(() => {
+    fetch('/api/stats/history')
+      .then(r => r.json())
+      .then(data => {
+        if (Array.isArray(data)) {
+          setSystemHistory(data.map((d: any) => ({
+            time: d.time,
+            cpu: d.cpu,
+            memory: d.memory,
+            gpu: d.gpu,
+            storage: d.disk,
+          })))
+          setNetworkHistory(data.map((d: any) => ({
+            time: d.time,
+            down: parseFloat(d.netDown) || 0,
+            up: parseFloat(d.netUp) || 0,
+          })))
+        }
+      })
+      .catch(() => { /* no history yet — first poll */ })
+  }, [])
+
   const fetchStats = async () => {
     if (isFetching.current) return
     isFetching.current = true
@@ -68,24 +91,22 @@ export function MetricsSection() {
       if (data && !data.error) {
         setStats(data)
         const now = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-        
-        // Calculate storage as percentage of a reasonable max (e.g., 2GB = 100%)
-        const totalStorageBytes = (data.storage || []).reduce((sum: number, s: StorageStat) => sum + s.bytes, 0)
-        const storagePerc = Math.min(100, (totalStorageBytes / (2 * 1024 * 1024 * 1024)) * 100)
-        
+
+        const diskPerc = data.diskUsedPerc ?? 0
+
         setSystemHistory(prev => [...prev, {
           time: now,
           cpu: parseFloat(data.cpu) || 0,
           memory: parseFloat(data.memPerc) || 0,
-          gpu: 0, // GPU not available from Docker stats
-          storage: storagePerc
-        }].slice(-30))
+          gpu: data?.gpu?.load ?? 0,
+          storage: diskPerc,
+        }].slice(-120))
 
         setNetworkHistory(prev => [...prev, {
           time: now,
           down: parseFloat(data.netDown) || 0,
-          up: parseFloat(data.netUp) || 0
-        }].slice(-30))
+          up: parseFloat(data.netUp) || 0,
+        }].slice(-120))
       }
     } catch (err) {
       console.error("Metrics offline")

--- a/Dashboard/Dashboard1/lib/db/index.ts
+++ b/Dashboard/Dashboard1/lib/db/index.ts
@@ -41,6 +41,20 @@ export function getDb(): Database.Database {
       value TEXT NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS metrics_history (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      created_at  INTEGER NOT NULL DEFAULT (unixepoch()),
+      cpu         REAL,
+      memory      REAL,
+      gpu         REAL,
+      disk        REAL,
+      net_down    REAL,
+      net_up      REAL
+    );
+
+    -- Keep only last 24h of metrics (auto-cleanup on each read)
+    -- Run periodically via index check
+
     INSERT OR IGNORE INTO app_state(key, value) VALUES ('setup_complete', '0');
   `)
 


### PR DESCRIPTION
## Phase 3 — Time-Series Charts with SQLite Persistence

| Feature | Before | After |
|---|---|---|
| History | In-memory, lost on refresh | SQLite table, persists 24h |
| System chart | Empty on load | Loads last 1h instantly |
| Network chart | Empty on load | Loads last 1h instantly |
| Storage calc | Fake '2GB = 100%' | Real disk % from df -h |

### Files Changed
- `lib/db/index.ts` — metrics_history table schema
- `app/api/stats/route.ts` — writes every poll, TTL cleanup
- `app/api/stats/history/route.ts` — new endpoint, last 120 readings
- `components/dashboard/metrics-section.tsx` — fetches history on mount, real disk %

Closes #138.