### PR TITLE
feat: Phase 5 — TIER 4 swap, load averages, network errors

### DIFF
--- a/Dashboard/Dashboard1/app/api/stats/route.ts
+++ b/Dashboard/Dashboard1/app/api/stats/route.ts
@@ -95,6 +95,51 @@ async function readUptime(): Promise<number | null> {
   } catch { return null }
 }
 
+// Swap usage — Linux only
+async function readSwap(): Promise<{ total: number; used: number; perc: number } | null> {
+  try {
+    const raw = fs.readFileSync('/proc/meminfo', 'utf-8')
+    const parse = (key: string) => {
+      const line = raw.split('\n').find(l => l.startsWith(key))
+      return line ? parseInt(line.split(/\s+/)[1]) * 1024 : 0 // kB → bytes
+    }
+    const total = parse('SwapTotal')
+    if (total === 0) return null // no swap configured
+    const free = parse('SwapFree')
+    const used = total - free
+    return { total, used, perc: total > 0 ? ((used / total) * 100) : 0 }
+  } catch { return null }
+}
+
+// System load averages — Linux only
+async function readLoadAverages(): Promise<{ load1: number; load5: number; load15: number } | null> {
+  try {
+    const raw = fs.readFileSync('/proc/loadavg', 'utf-8').trim()
+    const [load1, load5, load15] = raw.split(/\s+/).slice(0, 3).map(Number)
+    return { load1, load5, load15 }
+  } catch { return null }
+}
+
+// Network errors/dropped packets — Linux only
+async function readNetErrors(): Promise<{ rxErrors: number; txErrors: number; rxDropped: number; txDropped: number } | null> {
+  try {
+    const lines = fs.readFileSync('/proc/net/dev', 'utf-8').trim().split('\n').slice(2)
+    let rxErrors = 0, txErrors = 0, rxDropped = 0, txDropped = 0
+    for (const line of lines) {
+      const parts = line.trim().split(/\s+/)
+      const iface = parts[0].replace(':', '')
+      // Skip virtual interfaces
+      if (['lo', 'docker0', 'br-1'].some(p => iface.startsWith(p)) || iface.startsWith('veth')) continue
+      // Format: face |rx bytes packets errs drop fifo frame compressed multicast|tx bytes packets errs drop fifo colls carrier compressed
+      rxDropped += parseInt(parts[4]) || 0
+      rxErrors += parseInt(parts[3]) || 0
+      txDropped += parseInt(parts[12]) || 0
+      txErrors += parseInt(parts[11]) || 0
+    }
+    return { rxErrors, txErrors, rxDropped, txDropped }
+  } catch { return null }
+}
+
 // Container health via docker ps -a — includes exited/unhealthy containers
 async function readContainerHealth(projectContainers: any[]): Promise<any[]> {
   try {
@@ -168,7 +213,13 @@ export async function GET() {
     const temps = await readTemps(gpuData?.temp ?? null)
 
     // 5. Read disk usage % and uptime
-    const [diskPerc, uptimeDays] = await Promise.all([readDiskUsage(), readUptime()])
+    const [diskPerc, uptimeDays, swapData, loadAvg, netErrors] = await Promise.all([
+      readDiskUsage(),
+      readUptime(),
+      readSwap(),
+      readLoadAverages(),
+      readNetErrors(),
+    ])
 
     let totalCpu = 0
     let totalMemPerc = 0
@@ -224,6 +275,9 @@ export async function GET() {
       temps,
       diskUsedPerc: diskPerc,
       uptimeDays,
+      swap: swapData ? { total: swapData.total, used: swapData.used, perc: swapData.perc } : null,
+      loadAvg: loadAvg ? { load1: loadAvg.load1, load5: loadAvg.load5, load15: loadAvg.load15 } : null,
+      netErrors: netErrors || null,
     }
 
     // Write to SQLite history (every poll)

--- a/Dashboard/Dashboard1/components/dashboard/metrics-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/metrics-section.tsx
@@ -9,6 +9,7 @@ import { StorageLoad } from "../metrics/storage-load"
 import { DiskVolumes } from "../metrics/disk-volumes"
 import { NodeAlerts } from "../metrics/node-alerts"
 import { ActiveInfrastructure } from "../metrics/active-infrastructure"
+import { SystemDiagnostics } from "../metrics/system-diagnostics"
 
 interface ContainerStat {
   name: string
@@ -37,6 +38,9 @@ interface StatsData {
   temps: { cpu: number | null; gpu: number | null; sys: number | null }
   diskUsedPerc: number | null
   uptimeDays: number | null
+  swap: { total: number; used: number; perc: number } | null
+  loadAvg: { load1: number; load5: number; load15: number } | null
+  netErrors: { rxErrors: number; txErrors: number; rxDropped: number; txDropped: number } | null
 }
 
 interface SystemHistoryPoint {
@@ -159,6 +163,9 @@ export function MetricsSection() {
       <div className="flex-1 min-h-0 overflow-hidden">
         <ActiveInfrastructure stats={stats} />
       </div>
+
+      {/* Row 4: System Diagnostics — Swap, Load, Network Errors */}
+      <SystemDiagnostics stats={stats} />
     </div>
   )
 }

--- a/Dashboard/Dashboard1/components/metrics/system-diagnostics.tsx
+++ b/Dashboard/Dashboard1/components/metrics/system-diagnostics.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { ArrowDownUp, Activity, AlertCircle } from "lucide-react"
+
+interface SystemDiagnosticsProps {
+  stats: {
+    swap: { total: number; used: number; perc: number } | null
+    loadAvg: { load1: number; load5: number; load15: number } | null
+    netErrors: { rxErrors: number; txErrors: number; rxDropped: number; txDropped: number } | null
+  } | null
+}
+
+function humanBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)} MB`
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)} KB`
+  return `${bytes} B`
+}
+
+export function SystemDiagnostics({ stats }: SystemDiagnosticsProps) {
+  const totalNetIssues = (stats?.netErrors?.rxErrors ?? 0) + (stats?.netErrors?.txErrors ?? 0) +
+    (stats?.netErrors?.rxDropped ?? 0) + (stats?.netErrors?.txDropped ?? 0)
+
+  const panels = [
+    {
+      label: "Swap",
+      value: stats?.swap ? `${stats.swap.perc.toFixed(0)}%` : "N/A",
+      sub: stats?.swap ? `${humanBytes(stats.swap.used)} / ${humanBytes(stats.swap.total)}` : "Not configured",
+      icon: ArrowDownUp,
+      color: "#a855f7",
+      warn: stats?.swap ? stats.swap.perc > 50 : false,
+    },
+    {
+      label: "Load",
+      value: stats?.loadAvg ? `${stats.loadAvg.load1.toFixed(2)}` : "N/A",
+      sub: stats?.loadAvg ? `${stats.loadAvg.load5.toFixed(2)} · ${stats.loadAvg.load15.toFixed(2)}` : "—",
+      icon: Activity,
+      color: "#22d3ee",
+      warn: false,
+    },
+    {
+      label: "Net Issues",
+      value: totalNetIssues > 0 ? `${totalNetIssues}` : "0",
+      sub: totalNetIssues > 0 ? "Errors + dropped" : "Clean",
+      icon: AlertCircle,
+      color: totalNetIssues > 0 ? "#ef4444" : "#22c55e",
+      warn: totalNetIssues > 0,
+    },
+  ]
+
+  return (
+    <div className="flex gap-3">
+      {panels.map(panel => (
+        <div key={panel.label} className="flex-1 bg-card rounded-xl border border-border p-2.5 flex flex-col shadow-sm overflow-hidden">
+          <div className="flex items-center gap-2 shrink-0 mb-1">
+            <panel.icon className="w-3 h-3" style={{ color: panel.color }} />
+            <span className="text-[9px] font-black uppercase tracking-widest opacity-40 text-foreground">{panel.label}</span>
+          </div>
+          <div className="flex-1 flex items-baseline gap-1.5 min-h-0">
+            <span className={`text-lg font-bold tabular-nums ${panel.warn ? 'text-red-400' : 'text-foreground'}`}>
+              {panel.value}
+            </span>
+          </div>
+          <div className="text-[8px] font-mono opacity-30 text-foreground truncate mt-0.5">
+            {panel.sub}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Phase 5 — TIER 4 System Diagnostics

| Metric | Source | Display |
|---|---|---|
| Swap usage | /proc/meminfo | % + human-readable |
| Load averages | /proc/loadavg | 1m, 5m, 15m |
| Network errors | /proc/net/dev | errors + dropped (excludes virtual) |

All degrade to N/A on macOS/unavailable.

### Files Changed
- `app/api/stats/route.ts` — swap, load, net errors collectors
- `components/metrics/system-diagnostics.tsx` — new diagnostic panel
- `components/dashboard/metrics-section.tsx` — wired to layout

Closes #142.