### PR TITLE
fix: Matrix crash-loop fix — gen_config.py substitutes env vars into homeserver.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ docs/superpowers/
 Dashboard/Dashboard1/docs/superpowers/
 Dashboard/Dashboard1/tsconfig.tsbuildinfo
 config/matrix/element-config.json
+config/matrix/homeserver.yaml

--- a/config/matrix/entrypoint.sh
+++ b/config/matrix/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+# Substitute environment variables into homeserver.yaml before starting Synapse
+# This is needed because Synapse reads the config file directly and doesn't support
+# environment variable interpolation natively.
+INPUT="/data/homeserver.yaml.tpl"
+OUTPUT="/data/homeserver.yaml"
+
+if [ -f "$INPUT" ]; then
+    # Use envsubst-style replacement with sed
+    sed \
+        -e "s/\${MATRIX_DB_USER}/${MATRIX_DB_USER}/g" \
+        -e "s/\${MATRIX_DB_PASSWORD}/${MATRIX_DB_PASSWORD}/g" \
+        -e "s/\${MATRIX_REGISTRATION_SECRET}/${MATRIX_REGISTRATION_SECRET}/g" \
+        -e "s/\${MATRIX_MACAROON_SECRET_KEY}/${MATRIX_MACAROON_SECRET_KEY}/g" \
+        -e "s/\${MATRIX_FORM_SECRET}/${MATRIX_FORM_SECRET}/g" \
+        "$INPUT" > "$OUTPUT"
+    echo "[entrypoint] homeserver.yaml generated from template"
+else
+    echo "[entrypoint] Using existing homeserver.yaml (no template found)"
+fi
+
+# Start Synapse
+exec python -m synapse.app.homeserver -c /data/homeserver.yaml -c /data/localhost.log.config

--- a/config/matrix/gen_config.py
+++ b/config/matrix/gen_config.py
@@ -1,0 +1,13 @@
+import os
+
+with open('/etc/synapse-config/homeserver.yaml.tpl') as f:
+    content = f.read()
+
+for key in ['MATRIX_DB_USER', 'MATRIX_DB_PASSWORD', 'MATRIX_REGISTRATION_SECRET',
+            'MATRIX_MACAROON_SECRET_KEY', 'MATRIX_FORM_SECRET']:
+    content = content.replace(f'${{{key}}}', os.environ[key])
+
+with open('/data/homeserver.yaml', 'w') as f:
+    f.write(content)
+
+print('[entrypoint] homeserver.yaml generated from template')

--- a/config/matrix/homeserver.yaml.tpl
+++ b/config/matrix/homeserver.yaml.tpl
@@ -1,0 +1,48 @@
+# Matrix Synapse Homeserver Configuration
+# Generated for Project S HomeForge
+# Docs: https://element-hq.github.io/synapse/latest/usage/configuration/config_documentation.html
+
+server_name: "localhost"
+pid_file: /data/homeserver.pid
+
+listeners:
+  - port: 8008
+    tls: false
+    type: http
+    x_forwarded: true
+    resources:
+      - names: [client, federation]
+        compress: false
+
+database:
+  name: psycopg2
+  args:
+    user: "${MATRIX_DB_USER}"
+    password: "${MATRIX_DB_PASSWORD}"
+    database: synapse
+    host: synapse-db
+    port: 5432
+    cp_min: 5
+    cp_max: 10
+
+log_config: "/data/localhost.log.config"
+
+media_store_path: /data/media_store
+
+registration_shared_secret: "${MATRIX_REGISTRATION_SECRET}"
+
+report_stats: false
+
+macaroon_secret_key: "${MATRIX_MACAROON_SECRET_KEY}"
+
+form_secret: "${MATRIX_FORM_SECRET}"
+
+signing_key_path: "/data/localhost.signing.key"
+
+trusted_key_servers:
+  - server_name: "matrix.org"
+
+enable_registration: true
+enable_registration_without_verification: true
+
+suppress_key_server_warning: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -192,14 +192,14 @@ services:
       - '8008:8008'
     volumes:
       - ./data/matrix/synapse:/data
-      - ./config/matrix/homeserver.yaml:/data/homeserver.yaml:ro
-      - ./config/matrix/localhost.log.config:/data/localhost.log.config:ro
+      - ./config/matrix:/etc/synapse-config:ro
     environment:
       - MATRIX_REGISTRATION_SECRET=${MATRIX_REGISTRATION_SECRET}
       - MATRIX_MACAROON_SECRET_KEY=${MATRIX_MACAROON_SECRET_KEY}
       - MATRIX_FORM_SECRET=${MATRIX_FORM_SECRET}
       - MATRIX_DB_USER=${MATRIX_DB_USER}
       - MATRIX_DB_PASSWORD=${MATRIX_DB_PASSWORD}
+    entrypoint: ["/bin/sh", "-c", "python3 /etc/synapse-config/gen_config.py && cp /etc/synapse-config/localhost.log.config /data/localhost.log.config && exec python -m synapse.app.homeserver -c /data/homeserver.yaml -c /data/localhost.log.config"]
     restart: unless-stopped
     deploy:
       resources:


### PR DESCRIPTION
## Fix: Matrix Server Crash-Loop

### Problem
Matrix server crash-looped with:
```
psycopg2.OperationalError: password authentication failed for user "${MATRIX_DB_USER}"
```
The `homeserver.yaml` had literal `${MATRIX_DB_USER}` text — Docker env vars don't auto-substitute into config files.

### Fix
- Renamed `homeserver.yaml` → `homeserver.yaml.tpl`
- Added `gen_config.py` — substitutes env vars into template before starting Synapse
- Custom entrypoint runs gen_config.py → generates real `homeserver.yaml` → starts Synapse

### Files Changed
- `config/matrix/homeserver.yaml.tpl` (renamed from homeserver.yaml)
- `config/matrix/gen_config.py` (new — env var substitution)
- `docker-compose.yml` — updated synapse entrypoint and volume mounts
- `.gitignore` — ignore generated homeserver.yaml