### PR TITLE
feat: Phase 2 — Backup status widget + UPS monitoring (#147)

### DIFF
--- a/Dashboard/Dashboard1/app/api/stats/route.ts
+++ b/Dashboard/Dashboard1/app/api/stats/route.ts
@@ -170,6 +170,82 @@ async function readPower(): Promise<{ watts: number | null; kwhEstimate: number 
   return { watts: null, kwhEstimate: null }
 }
 
+// Backup status — checks common backup locations for last successful run
+async function readBackupStatus(): Promise<{ lastRun: number | null; lastRunAgo: string | null; success: boolean | null; size: string | null }> {
+  try {
+    // Check common backup locations under /data
+    const backupDirs = ['backups', 'backup', '.backups']
+    for (const dir of backupDirs) {
+      const backupPath = `/data/${dir}`
+      if (fs.existsSync(backupPath)) {
+        const entries = fs.readdirSync(backupPath, { withFileTypes: true })
+        // Look for recent files/dirs that indicate a successful backup
+        const backupFiles = entries
+          .filter(e => e.isFile() || e.isDirectory())
+          .map(e => {
+            const stat = fs.statSync(`${backupPath}/${e.name}`)
+            return { name: e.name, mtime: stat.mtimeMs, size: stat.size }
+          })
+          .sort((a, b) => b.mtime - a.mtime)
+
+        if (backupFiles.length > 0) {
+          const last = backupFiles[0]
+          const hoursAgo = Math.floor((Date.now() - last.mtime) / (1000 * 60 * 60))
+          const ago = hoursAgo < 1 ? 'Just now' : hoursAgo < 24 ? `${hoursAgo}h ago` : `${Math.floor(hoursAgo / 24)}d ago`
+          const size = last.size >= 1024 ** 3 ? `${(last.size / 1024 ** 3).toFixed(1)} GB` : `${(last.size / 1024 ** 2).toFixed(0)} MB`
+          return { lastRun: Math.floor(last.mtime / 1000), lastRunAgo: ago, success: true, size }
+        }
+        return { lastRun: null, lastRunAgo: null, success: null, size: null }
+      }
+    }
+  } catch { /* no backup dir found */ }
+  return { lastRun: null, lastRunAgo: null, success: null, size: null }
+}
+
+// UPS status — via apcupsd or /proc/acpi
+async function readUPSStatus(): Promise<{ batteryPerc: number | null; loadPerc: number | null; runtimeMin: number | null; status: string | null }> {
+  try {
+    // Try apcaccess first (APC UPS)
+    const { stdout } = await execAsync('apcaccess status 2>/dev/null | grep -E "^(BCHARGE|LOADPCT|TIMELEFT|STATUS):"', { timeout: 3000 })
+    const lines = stdout.trim().split('\n')
+    const data: Record<string, string> = {}
+    for (const line of lines) {
+      const [key, ...rest] = line.split(':')
+      if (key && rest) data[key.trim()] = rest.join(':').trim()
+    }
+
+    if (Object.keys(data).length > 0) {
+      const batteryPerc = data.BCHARGE ? parseFloat(data.BCHARGE) : null
+      const loadPerc = data.LOADPCT ? parseFloat(data.LOADPCT) : null
+      const runtimeMin = data.TIMELEFT ? parseFloat(data.TIMELEFT) : null
+      const status = data.STATUS || null
+      return { batteryPerc, loadPerc, runtimeMin, status }
+    }
+  } catch { /* apcaccess not available */ }
+
+  // Try NUT (Network UPS Tools)
+  try {
+    const { stdout } = await execAsync('upsc ups@localhost 2>/dev/null | grep -E "^(battery\\.charge|ups\\.load|battery\\.runtime|ups\\.status):"', { timeout: 3000 })
+    const lines = stdout.trim().split('\n')
+    const data: Record<string, string> = {}
+    for (const line of lines) {
+      const [key, value] = line.split(':')
+      if (key && value) data[key.trim()] = value.trim()
+    }
+
+    if (Object.keys(data).length > 0) {
+      return {
+        batteryPerc: data['battery.charge'] ? parseFloat(data['battery.charge']) : null,
+        loadPerc: data['ups.load'] ? parseFloat(data['ups.load']) : null,
+        runtimeMin: data['battery.runtime'] ? parseFloat(data['battery.runtime']) / 60 : null,
+        status: data['ups.status'] || null,
+      }
+    }
+  } catch { /* NUT not available */ }
+
+  return { batteryPerc: null, loadPerc: null, runtimeMin: null, status: null }
+}
+
 // Swap usage — Linux only
 async function readSwap(): Promise<{ total: number; used: number; perc: number } | null> {
   try {
@@ -288,7 +364,7 @@ export async function GET() {
     const temps = await readTemps(gpuData?.temp ?? null)
 
     // 5. Read disk usage % and uptime
-    const [diskPerc, uptimeDays, swapData, loadAvg, netErrors, diskBreakdown, smartHealth, powerData] = await Promise.all([
+    const [diskPerc, uptimeDays, swapData, loadAvg, netErrors, diskBreakdown, smartHealth, powerData, backupData, upsData] = await Promise.all([
       readDiskUsage(),
       readUptime(),
       readSwap(),
@@ -297,6 +373,8 @@ export async function GET() {
       readDiskBreakdown(),
       readSmartHealth(),
       readPower(),
+      readBackupStatus(),
+      readUPSStatus(),
     ])
 
     let totalCpu = 0
@@ -359,6 +437,8 @@ export async function GET() {
       disks: diskBreakdown,
       smart: smartHealth,
       power: powerData,
+      backup: backupData,
+      ups: upsData,
     }
 
     // Write to SQLite history (every poll)

--- a/Dashboard/Dashboard1/components/dashboard/metrics-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/metrics-section.tsx
@@ -38,6 +38,8 @@ interface StatsData {
   disks: Array<{ mount: string; total: string; used: string; avail: string; usePerc: number; device: string }>
   smart: Array<{ device: string; model: string; temperature: number | null; powerOnHours: number | null; health: string; reallocated: number | null }>
   power: { watts: number | null; kwhEstimate: number | null }
+  backup: { lastRun: number | null; lastRunAgo: string | null; success: boolean | null; size: string | null }
+  ups: { batteryPerc: number | null; loadPerc: number | null; runtimeMin: number | null; status: string | null }
 }
 
 interface HistoryPoint {
@@ -448,6 +450,61 @@ export function MetricsSection() {
                   <div className="text-[9px] text-foreground/25 uppercase tracking-wider">Cumulative Energy</div>
                   <div className="text-lg font-mono font-semibold text-foreground tabular-nums mt-0.5">{stats.power.kwhEstimate.toFixed(2)} kWh</div>
                   {stats.power.watts !== null && <div className="text-[9px] text-foreground/15 tabular-nums">{stats.power.watts.toFixed(0)}W current</div>}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Backup + UPS row */}
+        {(stats.backup.lastRunAgo !== null || stats.ups.batteryPerc !== null) && (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {/* Backup Status */}
+            <div>
+              <SectionHeader title="Backup" />
+              <div className="bg-secondary/5 rounded-lg p-3">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <div className="text-[9px] text-foreground/25 uppercase tracking-wider">Last Backup</div>
+                    <div className="text-base font-mono font-semibold text-foreground tabular-nums mt-0.5">{stats.backup.lastRunAgo || "Never"}</div>
+                    {stats.backup.size && <div className="text-[9px] text-foreground/15 tabular-nums">{stats.backup.size}</div>}
+                  </div>
+                  {stats.backup.success !== null && (
+                    <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-[9px] font-bold uppercase" style={{ backgroundColor: stats.backup.success ? '#22c55e15' : '#ef444415', color: stats.backup.success ? '#22c55e' : '#ef4444' }}>
+                      <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: stats.backup.success ? '#22c55e' : '#ef4444' }} />
+                      {stats.backup.success ? 'Success' : 'Failed'}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* UPS Status */}
+            {stats.ups.batteryPerc !== null && (
+              <div>
+                <SectionHeader title="UPS" />
+                <div className="bg-secondary/5 rounded-lg p-3">
+                  <div className="grid grid-cols-3 gap-4">
+                    <div>
+                      <div className="text-[9px] text-foreground/25 uppercase tracking-wider">Battery</div>
+                      <div className="text-base font-mono font-semibold text-foreground tabular-nums mt-0.5">{stats.ups.batteryPerc}%</div>
+                    </div>
+                    <div>
+                      <div className="text-[9px] text-foreground/25 uppercase tracking-wider">Load</div>
+                      <div className="text-base font-mono font-semibold text-foreground tabular-nums mt-0.5">{stats.ups.loadPerc ? `${stats.ups.loadPerc}%` : "—"}</div>
+                    </div>
+                    <div>
+                      <div className="text-[9px] text-foreground/25 uppercase tracking-wider">Runtime</div>
+                      <div className="text-base font-mono font-semibold text-foreground tabular-nums mt-0.5">{stats.ups.runtimeMin ? `${stats.ups.runtimeMin.toFixed(0)}m` : "—"}</div>
+                    </div>
+                  </div>
+                  {stats.ups.status && (
+                    <div className="mt-1">
+                      <span className="text-[9px] font-medium" style={{ color: stats.ups.status === 'OL' ? '#22c55e' : '#f59e0b' }}>
+                        {stats.ups.status === 'OL' ? 'Online' : stats.ups.status}
+                      </span>
+                    </div>
+                  )}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Phase 2 of #147 — Backup + UPS

| Feature | Source | Display |
|---|---|---|
| Backup status | Scans /data/backups, /data/backup, /data/.backups | Last run time ago + pass/fail badge + size |
| UPS monitoring | apcaccess (APC) or upsc (NUT) | Battery %, load %, runtime, status |

Both degrade gracefully when unavailable.

### Files Changed
- `app/api/stats/route.ts` — readBackupStatus(), readUPSStatus()
- `components/dashboard/metrics-section.tsx` — Backup + UPS widgets

Closes #152, supports #147.