### PR TITLE
feat: Phase 1 — Dock bounce animation + active dot indicator (#112)

### DIFF
--- a/Dashboard/Dashboard1/app/page.tsx
+++ b/Dashboard/Dashboard1/app/page.tsx
@@ -266,6 +266,19 @@ export default function HomePage() {
             transform: translate(5%, -3%) rotate(1.5deg) scale(1.01);
           }
         }
+
+        /* macOS Dock-style bounce animation */
+        @keyframes bounce-dock {
+          0%, 100% { transform: translateY(0); }
+          20% { transform: translateY(-8px); }
+          40% { transform: translateY(2px); }
+          60% { transform: translateY(-4px); }
+          80% { transform: translateY(1px); }
+        }
+
+        .animate-bounce-dock {
+          animation: bounce-dock 0.6s ease-in-out;
+        }
         
         html {
           scroll-behavior: smooth;

--- a/Dashboard/Dashboard1/components/dashboard/sidebar.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/sidebar.tsx
@@ -43,7 +43,15 @@ export function Sidebar({
   const IS_LANDING = process.env.NEXT_PUBLIC_LANDING_MODE === 'true'
   const [showSettings, setShowSettings] = useState(false)
   const [showThemes, setShowThemes] = useState(false)
+  const [bouncingId, setBouncingId] = useState<string | null>(null)
   const { colorTheme, setColorTheme } = useTheme()
+
+  // Trigger bounce animation on dock click
+  const handleBounceClick = (id: string) => {
+    setBouncingId(id)
+    onDockAppClick?.(id)
+    setTimeout(() => setBouncingId(null), 600)
+  }
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -107,24 +115,29 @@ export function Sidebar({
                 return (
                   <Tooltip key={app.id}>
                     <TooltipTrigger asChild>
-                      <button
-                        onClick={() => onDockAppClick?.(app.id)}
-                        className="relative flex h-9 w-9 items-center justify-center rounded-xl transition-all duration-300"
-                        style={{
-                          backgroundColor: isActive
-                            ? colorTheme.accent
-                            : isClosing
-                            ? `${colorTheme.accent}08`
-                            : `${colorTheme.accent}15`,
-                          color: isActive
-                            ? colorTheme.accentForeground
-                            : colorTheme.accent,
-                          opacity: isClosing ? 0.3 : 1,
-                          filter: isClosing ? 'grayscale(1)' : 'none',
-                        }}
-                      >
-                        <Icon className="h-[18px] w-[18px]" strokeWidth={1.5} />
-                      </button>
+                      <div className="relative flex flex-col items-center">
+                        <button
+                          onClick={() => handleBounceClick(app.id)}
+                          className={`relative flex h-9 w-9 items-center justify-center rounded-xl transition-all duration-300 ${bouncingId === app.id ? 'animate-bounce-dock' : ''}`}
+                          style={{
+                            backgroundColor: isActive
+                              ? colorTheme.accent
+                              : isClosing
+                              ? `${colorTheme.accent}08`
+                              : `${colorTheme.accent}15`,
+                            color: isActive
+                              ? colorTheme.accentForeground
+                              : colorTheme.accent,
+                            opacity: isClosing ? 0.3 : 1,
+                            filter: isClosing ? 'grayscale(1)' : 'none',
+                          }}
+                        >
+                          <Icon className="h-[18px] w-[18px]" strokeWidth={1.5} />
+                        </button>
+                        {isActive && (
+                          <span className="w-1 h-1 rounded-full mt-0.5" style={{ backgroundColor: colorTheme.accent }} />
+                        )}
+                      </div>
                     </TooltipTrigger>
                     <TooltipContent side="right" sideOffset={12}>
                       <p>


### PR DESCRIPTION
## Phase 1 of #112 — Dock UX Polish

### What's new
| Feature | Before | After |
|---|---|---|
| Bounce animation | None | macOS dock-style bounce on app launch (0.6s, 3 cycles) |
| Active dot indicator | None | Small dot below sidebar icon while section is open |

### How it works
- Click any dock icon → bounces up/down 3 times then settles
- Active window → shows accent-colored dot below icon
- Minimized/closing → no dot, icon dims

### Files Changed
- `components/dashboard/sidebar.tsx` — bounce state, dot indicator, handleBounceClick
- `app/page.tsx` — `@keyframes bounce-dock` CSS animation

Closes #155, addresses #112.