### PR TITLE
fix: Home/Metrics unhighlight when internal app is open

### DIFF
--- a/Dashboard/Dashboard1/app/page.tsx
+++ b/Dashboard/Dashboard1/app/page.tsx
@@ -199,6 +199,7 @@ export default function HomePage() {
       <Sidebar
         activeSection={openWindows.some(w => !w.isClosing) ? "app" : currentSection}
         currentSection={currentSection}
+        hasOpenWindow={openWindows.some(w => !w.isMinimized && !w.isClosing)}
         onNavigate={handleNavigate}
         terminalOpen={terminalOpen}
         onToggleTerminal={() => setTerminalOpen(prev => !prev)}

--- a/Dashboard/Dashboard1/components/dashboard/sidebar.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/sidebar.tsx
@@ -25,6 +25,7 @@ interface SidebarProps {
   className?: string
   activeSection?: string
   currentSection?: string
+  hasOpenWindow?: boolean
   onNavigate?: (section: string) => void
   terminalOpen?: boolean
   onToggleTerminal?: () => void
@@ -36,6 +37,7 @@ export function Sidebar({
   className,
   activeSection = "home",
   currentSection = "home",
+  hasOpenWindow = false,
   onNavigate,
   terminalOpen, 
   onToggleTerminal,
@@ -90,14 +92,14 @@ export function Sidebar({
           <NavButton
             icon={LayoutGrid}
             label="Home"
-            active={currentSection === "home"}
+            active={!hasOpenWindow && currentSection === "home"}
             onClick={() => onNavigate?.("home")}
             theme={colorTheme}
           />
           <NavButton
             icon={Activity}
             label="Metrics"
-            active={currentSection === "metrics"}
+            active={!hasOpenWindow && currentSection === "metrics"}
             onClick={() => onNavigate?.("metrics")}
             theme={colorTheme}
           />


### PR DESCRIPTION
## Fix: Dock Highlighting

### Problem
Home and Metrics stay highlighted even when an internal app (Ollama/Kiwix) is open and active.

### Fix
Added `hasOpenWindow` prop to Sidebar. Home/Metrics only highlight when no internal app is open.

### Files Changed
- `components/dashboard/sidebar.tsx` — hasOpenWindow prop, conditional highlighting
- `app/page.tsx` — passes hasOpenWindow to Sidebar