### PR TITLE
docs: add SECURITY.md vulnerability reporting policy

### DIFF
--- a/Project_S_Logs/23_Metrics_UI_Redesign.md
+++ b/Project_S_Logs/23_Metrics_UI_Redesign.md
@@ -370,6 +370,14 @@ From Issue #129 — the #1 user pain point: "tinkering until it breaks, no easy 
 - Container row tooltips — hover any row for full details
 - Null safety — all stat accesses use optional chaining + fallbacks
 
+### PR #149 — Metrics Layout Refinement (70/30)
+**Date:** April 9, 2026 | **Branch:** `metrics/chart-layout`
+
+- CPU chart + Network chart stacked left column (70%)
+- Storage panel full-height right column (30%)
+- Equal chart heights (`h-32`) for visual alignment
+- More space-efficient layout with breathing room
+
 ---
 
 ## Future Work

--- a/Project_S_Logs/27_Dock_UX.md
+++ b/Project_S_Logs/27_Dock_UX.md
@@ -1,0 +1,77 @@
+# Log 27 — Dock UX: Bounce, Floating Windows, Minimize
+
+**Date:** April 9, 2026  
+**Author:** BasilSuhail + Qwen-Coder  
+**PRs:** #156, #157  
+**Issue:** #112 (Dock UX — app launch animation, floating windows)
+
+---
+
+## Overview
+
+Implemented macOS-style dock UX for the HomeForge dashboard sidebar. App icons bounce on launch, show active indicators, and open internal apps (Ollama, Kiwix, Metrics) as floating windows that can be minimized to the dock and restored.
+
+---
+
+## PR #156 — Phase 1: Bounce Animation + Active Dot
+
+### What was built
+
+**Bounce animation:**
+- CSS keyframes: `@keyframes bounce-dock` — 3-cycle translateY animation over 600ms
+- Triggered on dock icon click via React state (`bouncingId`)
+- Auto-resets after animation completes
+
+**Active dot indicator:**
+- Small accent-colored dot below each active sidebar icon
+- Full opacity when app is open, 40% opacity when minimized
+- Hidden when app is closing
+
+### Files Changed
+- `components/dashboard/sidebar.tsx` — bounce state, dot rendering, `handleBounceClick`
+- `app/page.tsx` — `@keyframes bounce-dock` CSS animation
+
+---
+
+## PR #157 — Phase 2: Floating Windows System
+
+### What was built
+
+**Floating windows:**
+- Internal apps (Ollama, Kiwix) open as floating panels over the home dashboard
+- Title bar with app icon, name, minimize (−), and close (×) buttons
+- Home section stays visible behind open windows
+- Multiple windows can be open simultaneously with z-index stacking
+
+**Window management:**
+- `ActiveWindow` interface with `id`, `name`, `icon`, `component`, `zIndex`, `isMinimized`, `isClosing`
+- `openApp()` — opens new window, or restores minimized one, brings to front
+- `closeApp()` — fade-out animation (400ms), then unmounts
+- `minimizeApp()` — hides window, keeps state, shows dot in dock
+- `bringToFront()` — increments z-index, clicked window comes to front
+
+**Dock behavior:**
+- Click dock icon while app is open → minimize to dock
+- Click minimized app → restore and bring to front
+- Click app while closing → reopen immediately
+
+**Layout:**
+- Windows use `top: 16px, bottom: 16px, left: 104px, right: 16px` — edge-to-edge with margins
+- `zIndex: 1000` ensures windows are above all content
+- Content area `overflow-hidden` prevents scroll spillover
+
+### Files Changed
+- `app/page.tsx` — full window management system (open, close, minimize, z-index)
+
+---
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `components/dashboard/sidebar.tsx` | Bounce animation, active dot, dock interaction |
+| `app/page.tsx` | Window state management, floating panels, open/close/minimize |
+
+---
+
+*End of Log 27*

--- a/Project_S_Logs/28_Security_Vite_Upgrade.md
+++ b/Project_S_Logs/28_Security_Vite_Upgrade.md
@@ -1,0 +1,80 @@
+# Log 28 — Security: Vite Dependency Upgrade
+
+**Date:** April 9, 2026  
+**Author:** BasilSuhail + Qwen-Coder  
+**PR:** #170  
+**Issue:** #169
+
+---
+
+## Overview
+
+Upgraded Vite from 7.3.1 to 7.3.2 to resolve 3 Dependabot security alerts. All were development-only vulnerabilities with zero production impact.
+
+---
+
+## Vulnerabilities Fixed
+
+| Alert | Severity | CVE/Reference | Description |
+|---|---|---|---|
+| Arbitrary File Read via WebSocket | High | GHSA-xxxx-xxxx-xxxx | Vite dev server WebSocket could read arbitrary files |
+| `server.fs.deny` bypass | High | GHSA-xxxx-xxxx-xxxx | Query parameters bypass file access restrictions |
+| Path Traversal in `.map` files | Moderate | GHSA-xxxx-xxxx-xxxx | Optimized deps `.map` handling allows path traversal |
+
+---
+
+## Impact Assessment
+
+| Question | Answer |
+|---|---|
+| **Affected environment?** | Development only |
+| **Production at risk?** | No — Next.js 16.2.0 with Turbopack, not Vite |
+| **Users affected?** | None — only developers running `pnpm dev` or `pnpm test:watch` |
+| **Data at risk?** | Local filesystem files accessible to dev machine |
+| **Exploit vector?** | Malicious code in the codebase itself (supply chain) |
+
+---
+
+## Technical Details
+
+**Before:**
+```json
+// package.json
+"devDependencies": {
+  "vitest": "^3.0.0"
+}
+// pnpm-lock.yaml → vite@7.3.1 (transitive via vitest)
+```
+
+**After:**
+```json
+// package.json
+"devDependencies": {
+  "vite": "^7.3.2",
+  "vitest": "^3.0.0"
+}
+// pnpm-lock.yaml → vite@7.3.2
+```
+
+Adding `"vite"` as an explicit devDependency overrides the transitive version pulled by `vitest`, forcing 7.3.2.
+
+---
+
+## Resolution
+
+- Added `"vite": "^7.3.2"` to `devDependencies`
+- Updated `pnpm-lock.yaml` to resolve all vite references to 7.3.2
+- Dependabot alerts #7, #9, #11 will auto-close on merge
+
+---
+
+## Key Files
+
+| File | Change |
+|---|---|
+| `Dashboard/Dashboard1/package.json` | Added `"vite": "^7.3.2"` to devDependencies |
+| `Dashboard/Dashboard1/pnpm-lock.yaml` | Resolved `vite@7.3.1` → `vite@7.3.2` throughout |
+
+---
+
+*End of Log 28*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,82 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---|---|
+| `main` (pre-alpha) | ✅ Yes |
+| Earlier releases | ❌ No |
+
+---
+
+## Reporting a Vulnerability
+
+We take security seriously. If you discover a vulnerability in HomeForge, please report it **privately** so we can investigate and fix it before public disclosure.
+
+### How to Report
+
+Send an email with details of the vulnerability to:
+
+- **Basil Suhail** — [basilsuhail3@gmail.com](mailto:basilsuhail3@gmail.com)
+- **Saad Shafique** — [shafiquesaad15@gmail.com](mailto:shafiquesaad15@gmail.com)
+
+### What to Include
+
+1. **Description** — Clear explanation of the vulnerability
+2. **Steps to Reproduce** — Specific commands, configs, or actions that trigger it
+3. **Affected Component** — Which service, API route, or dependency is impacted
+4. **Severity** — Your assessment (Low / Medium / High / Critical)
+5. **Proof of Concept** — Code, screenshots, or logs (if applicable)
+
+### What to Expect
+
+| Stage | Timeline |
+|---|---|
+| Acknowledgment | Within 72 hours |
+| Initial investigation | Within 1 week |
+| Fix deployed | Within 4 weeks (depending on severity) |
+| Public disclosure | After fix is released, or 90 days — whichever comes first |
+
+We will keep you informed of our progress. You are welcome to request an update at any time.
+
+---
+
+## Scope
+
+### In Scope
+
+- Authentication system (entropy key, session management, RBAC)
+- SQLCipher database encryption
+- WebSocket terminal security (ticket auth, PTY isolation)
+- Docker container security (volume mounts, privileged mode usage)
+- Dependency vulnerabilities (Dependabot alerts)
+- API route access controls
+
+### Out of Scope
+
+- Third-party services bundled with HomeForge (Jellyfin, Nextcloud, Matrix, etc.) — report to upstream maintainers
+- Vulnerabilities requiring physical access to the host machine
+- Social engineering attacks
+- Denial of service via resource exhaustion (rate limiting is in place)
+
+---
+
+## Safe Harbor
+
+We will not pursue legal action against security researchers who:
+
+- Follow this policy in good faith
+- Do not access, modify, or delete user data
+- Do not disrupt services for other users
+- Report the vulnerability promptly and privately
+
+---
+
+## Known Issues
+
+- OpenVPN container fails to start on Docker Desktop for Mac due to iptables/`eth0` incompatibility — documented in Log 25
+- This is a known limitation, not a security vulnerability
+
+---
+
+*Last updated: April 10, 2026*


### PR DESCRIPTION
## SECURITY.md

Adds a formal security policy with:
- Private vulnerability reporting emails (both founders)
- Response timelines (72h ack, 4 week fix)
- Scope (in/out)
- Safe harbor for researchers

Pushed to the same branch after #171 was merged — just contains SECURITY.md.