### PR TITLE
feat: Network segmentation — frontend, backend, database

### DIFF
--- a/.github/ISSUES/001-architecture-overhaul.md
+++ b/.github/ISSUES/001-architecture-overhaul.md
@@ -1,0 +1,149 @@
+# Architecture Overhaul — Single Source of Truth
+
+## Problem Statement
+
+The HomeForge architecture has grown organically across 28 implementation logs without a central architecture document. The current stack has structural gaps that will block scaling, onboarding, and production readiness:
+
+1. **No reverse proxy in the running stack** — `config/nginx/nginx.conf` exists but the nginx container is **not** in `docker-compose.yml`. All 15 services expose raw ports directly to the host. No SSL, no unified routing, no CSP centralization.
+2. **Flat network topology** — All containers share the default compose network. Databases (MariaDB, Postgres, Synapse DB), internal services (Ollama), and public-facing services (Nextcloud, Jellyfin, Matrix) are all on the same flat network with no segmentation.
+3. **Dashboard is an undifferentiated monolith** — Auth, session management, encrypted SQLite, WebSocket terminal, backup system, metrics aggregation, Kiwix API, Ollama proxy — all in one Next.js app with no internal layer boundaries documented.
+4. **No Architecture Decision Records** — Key decisions (Docker vs K8s, entropy-based auth, SQLCipher, HKDF key derivation) are buried in logs or discussed in conversations. New contributors (or future us) have no structured trail.
+5. **Documentation is scattered** — 28 markdown files in `Project_S_Logs/`, a README, a SECURITY.md, but no **architecture document** that ties system design, data flow, security boundaries, and deployment model together.
+6. **Data volume structure is ad-hoc** — `./data/` mixes config, state, and user data with no documented hierarchy. The backup system works against this loose structure but there's no contract.
+
+---
+
+## Goals
+
+| Goal | Success Metric |
+|---|---|
+| Single architecture document | One file (`docs/ARCHITECTURE.md`) that a new dev can read and understand the entire system in 15 minutes |
+| ADR trail | Every major architectural decision has a numbered record in `docs/decisions/` |
+| Network segmentation | `docker-compose.yml` defines `frontend`, `backend`, `database` networks; databases are unreachable from outside the compose stack |
+| Reverse proxy live | Nginx container is in compose, proxies all user-facing services, SSL-ready config structure |
+| Dashboard internal map | Layer diagram showing auth → session → DB → API routes → WebSocket |
+| Backup system contract | Documented data hierarchy that the backup/restore system depends on |
+
+---
+
+## Implementation Checklist
+
+### Phase 1 — Documentation (Foundation)
+- [ ] **1.1** Create `docs/ARCHITECTURE.md` — system overview with:
+  - [ ] High-level system diagram (ASCII or Mermaid)
+  - [ ] Service catalog (all 15 services, purpose, port, dependencies)
+  - [ ] Network topology (current + target)
+  - [ ] Data flow: user request → nginx → dashboard → service
+  - [ ] Security boundaries: encryption at rest, in transit, key derivation chain
+  - [ ] Deployment model: `boom.sh` → `.env` → `docker compose up`
+  - [ ] Backup & restore data hierarchy
+- [ ] **1.2** Create `docs/decisions/` directory with ADR template
+- [ ] **1.3** Write ADR-0001: _Use Docker Compose over Kubernetes_ (from Log 21)
+- [ ] **1.4** Write ADR-0002: _Entropy-based authentication with HKDF key derivation_ (from Log 24)
+- [ ] **1.5** Write ADR-0003: _SQLCipher for user database encryption at rest_
+- [ ] **1.6** Write ADR-0004: _Dashboard as central control plane (single Next.js monolith)_
+- [ ] **1.7** Write ADR-0005: _Nginx reverse proxy for all user-facing services_
+- [ ] **1.8** Write ADR-0006: _Flat data volume structure under `./data/`_
+- [ ] **1.9** Update `README.md` to link to `docs/ARCHITECTURE.md` as the primary technical reference
+
+### Phase 2 — Network Segmentation
+- [ ] **2.1** Define three Docker networks in `docker-compose.yml`:
+  - `frontend` — nginx, dashboard, element, openvpn-ui, kiwix-manager, open-webui
+  - `backend` — jellyfin, nextcloud, collabora, theia, synapse, vaultwarden, kiwix, ollama, openvpn
+  - `database` — db (MariaDB), synapse-db (Postgres)
+- [ ] **2.2** Assign each service to appropriate network(s)
+  - Dashboard: `frontend` + `backend` (needs to reach services for health checks)
+  - Nginx: `frontend` only (proxies to dashboard)
+  - Nextcloud: `backend` + `database`
+  - Synapse: `backend` + `database`
+  - Databases: `database` only (not reachable from frontend)
+- [ ] **2.3** Remove unnecessary `ports` declarations from internal-only services (Ollama:11434, databases)
+- [ ] **2.4** Verify all inter-service communication still works after segmentation
+
+### Phase 3 — Reverse Proxy Integration
+- [ ] **3.1** Add nginx service to `docker-compose.yml`
+- [ ] **3.2** Update `config/nginx/nginx.conf` to cover **all** user-facing services (currently only covers 5 of 15)
+- [ ] **3.3** Add WebSocket upgrade support to nginx config (needed for dashboard terminal, Matrix)
+- [ ] **3.4** Add healthcheck for nginx container
+- [ ] **3.5** Document SSL certificate strategy (placeholders for future Let's Encrypt / self-signed)
+- [ ] **3.6** Update `boom.sh` and `install.sh` to reference nginx as the primary entry point
+- [ ] **3.7** Test full stack with nginx as the single entry point
+
+### Phase 4 — Dashboard Internal Architecture
+- [ ] **4.1** Create `Dashboard/Dashboard1/docs/ARCHITECTURE.md` — internal dashboard architecture:
+  - [ ] Layer diagram: middleware → auth → session → DB → API routes → WebSocket server
+  - [ ] Data model: user schema, session schema, encryption key chain
+  - [ ] API route map with auth requirements per route
+  - [ ] WebSocket ticket flow diagram
+  - [ ] Backup/restore flow
+- [ ] **4.2** Document the entropy key derivation chain visually (HKDF → SESSION_SECRET, WS_SECRET, DB_KEY)
+- [ ] **4.3** Add inline architecture comments to key files (`middleware.ts`, `lib/auth.ts`, `lib/session.ts`)
+
+### Phase 5 — Data Volume Contract
+- [ ] **5.1** Document the `./data/` hierarchy in `docs/ARCHITECTURE.md`:
+  ```
+  data/
+  ├── jellyfin/        # Jellyfin config + cache
+  ├── nextcloud/       # Nextcloud html + data + db
+  ├── matrix/          # Synapse data + config
+  ├── vaultwarden/     # Password vault data
+  ├── open-webui/      # AI chat backend data
+  ├── ollama/          # LLM models
+  ├── kiwix/           # ZIM files + library
+  ├── vpn/             # OpenVPN config + certs
+  ├── workspace/       # Shared workspace (Theia)
+  ├── filebrowser/     # Kiwix manager DB
+  ├── security/        # Dashboard entropy DB
+  └── backups/         # User-initiated backups
+  ```
+- [ ] **5.2** Ensure backup system (`app/api/backup/`) documents what it includes/excludes
+- [ ] **5.3** Add a `data/README.md` or reference in main architecture doc
+
+### Phase 6 — Validation & Cleanup
+- [ ] **6.1** Full stack rebuild: `docker compose down && docker compose up -d`
+- [ ] **6.2** Verify all services reachable through correct paths
+- [ ] **6.3** Run CI: `npm test` in Dashboard, `docker compose config`
+- [ ] **6.4** Remove orphaned or duplicate configs
+- [ ] **6.5** Update `SECURITY.md` if network segmentation changes the attack surface
+
+---
+
+## Out of Scope (Future Issues)
+
+| Item | Reason |
+|---|---|
+| Kubernetes migration | Documented as Phase 3 in Log 21 — not for v0.1.0 |
+| SSL/TLS certificate automation | Requires domain setup, DNS, cert-manager — separate issue |
+| Dashboard microservice split | Intentionally monolithic for v0.1.0 — revisit post-beta |
+| Multi-node / Swarm | Phase 2 (Dokploy) per Log 21 |
+| Mobile app (React Native) | Phase 1 task 43 — separate concern |
+
+---
+
+## Dependencies & Risks
+
+| Risk | Mitigation |
+|---|---|
+| Network segmentation breaks inter-service communication | Test each service after segmentation; keep `depends_on` intact |
+| Nginx config is complex for 15 services | Build incrementally; test each proxy block individually |
+| Removing direct ports breaks existing user workflows | Document port changes clearly in release notes; keep optional direct-access env vars |
+| ADRs become stale | ADRs are append-only; new decisions supersede old ones, never edit |
+
+---
+
+## Acceptance Criteria
+
+- [ ] `docs/ARCHITECTURE.md` exists and covers: system diagram, service catalog, network topology, data flow, security model, deployment model, backup contract
+- [ ] `docs/decisions/` contains at least 6 numbered ADRs
+- [ ] `docker-compose.yml` defines `frontend`, `backend`, `database` networks
+- [ ] Nginx container is in compose and proxies all user-facing services
+- [ ] Database ports (3306, 5432) are NOT exposed to the host
+- [ ] `README.md` links to architecture doc as primary technical reference
+- [ ] Full stack builds and passes health checks
+- [ ] Dashboard tests pass (`npm test`)
+
+---
+
+**Labels:** `type: architecture`, `priority: high`, `scope: project-wide`
+**Assignees:** BasilSuhail, saadsh15
+**Estimate:** Multi-phase — track each phase independently

--- a/.github/ISSUE_TEMPLATE/architecture-overhaul.md
+++ b/.github/ISSUE_TEMPLATE/architecture-overhaul.md
@@ -1,0 +1,149 @@
+# Architecture Overhaul — Single Source of Truth
+
+## Problem Statement
+
+The HomeForge architecture has grown organically across 28 implementation logs without a central architecture document. The current stack has structural gaps that will block scaling, onboarding, and production readiness:
+
+1. **No reverse proxy in the running stack** — `config/nginx/nginx.conf` exists but the nginx container is **not** in `docker-compose.yml`. All 15 services expose raw ports directly to the host. No SSL, no unified routing, no CSP centralization.
+2. **Flat network topology** — All containers share the default compose network. Databases (MariaDB, Postgres, Synapse DB), internal services (Ollama), and public-facing services (Nextcloud, Jellyfin, Matrix) are all on the same flat network with no segmentation.
+3. **Dashboard is an undifferentiated monolith** — Auth, session management, encrypted SQLite, WebSocket terminal, backup system, metrics aggregation, Kiwix API, Ollama proxy — all in one Next.js app with no internal layer boundaries documented.
+4. **No Architecture Decision Records** — Key decisions (Docker vs K8s, entropy-based auth, SQLCipher, HKDF key derivation) are buried in logs or discussed in conversations. New contributors (or future us) have no structured trail.
+5. **Documentation is scattered** — 28 markdown files in `Project_S_Logs/`, a README, a SECURITY.md, but no **architecture document** that ties system design, data flow, security boundaries, and deployment model together.
+6. **Data volume structure is ad-hoc** — `./data/` mixes config, state, and user data with no documented hierarchy. The backup system works against this loose structure but there's no contract.
+
+---
+
+## Goals
+
+| Goal | Success Metric |
+|---|---|
+| Single architecture document | One file (`docs/ARCHITECTURE.md`) that a new dev can read and understand the entire system in 15 minutes |
+| ADR trail | Every major architectural decision has a numbered record in `docs/decisions/` |
+| Network segmentation | `docker-compose.yml` defines `frontend`, `backend`, `database` networks; databases are unreachable from outside the compose stack |
+| Reverse proxy live | Nginx container is in compose, proxies all user-facing services, SSL-ready config structure |
+| Dashboard internal map | Layer diagram showing auth → session → DB → API routes → WebSocket |
+| Backup system contract | Documented data hierarchy that the backup/restore system depends on |
+
+---
+
+## Implementation Checklist
+
+### Phase 1 — Documentation (Foundation)
+- [ ] **1.1** Create `docs/ARCHITECTURE.md` — system overview with:
+  - [ ] High-level system diagram (ASCII or Mermaid)
+  - [ ] Service catalog (all 15 services, purpose, port, dependencies)
+  - [ ] Network topology (current + target)
+  - [ ] Data flow: user request → nginx → dashboard → service
+  - [ ] Security boundaries: encryption at rest, in transit, key derivation chain
+  - [ ] Deployment model: `boom.sh` → `.env` → `docker compose up`
+  - [ ] Backup & restore data hierarchy
+- [ ] **1.2** Create `docs/decisions/` directory with ADR template
+- [ ] **1.3** Write ADR-0001: _Use Docker Compose over Kubernetes_ (from Log 21)
+- [ ] **1.4** Write ADR-0002: _Entropy-based authentication with HKDF key derivation_ (from Log 24)
+- [ ] **1.5** Write ADR-0003: _SQLCipher for user database encryption at rest_
+- [ ] **1.6** Write ADR-0004: _Dashboard as central control plane (single Next.js monolith)_
+- [ ] **1.7** Write ADR-0005: _Nginx reverse proxy for all user-facing services_
+- [ ] **1.8** Write ADR-0006: _Flat data volume structure under `./data/`_
+- [ ] **1.9** Update `README.md` to link to `docs/ARCHITECTURE.md` as the primary technical reference
+
+### Phase 2 — Network Segmentation
+- [ ] **2.1** Define three Docker networks in `docker-compose.yml`:
+  - `frontend` — nginx, dashboard, element, openvpn-ui, kiwix-manager, open-webui
+  - `backend` — jellyfin, nextcloud, collabora, theia, synapse, vaultwarden, kiwix, ollama, openvpn
+  - `database` — db (MariaDB), synapse-db (Postgres)
+- [ ] **2.2** Assign each service to appropriate network(s)
+  - Dashboard: `frontend` + `backend` (needs to reach services for health checks)
+  - Nginx: `frontend` only (proxies to dashboard)
+  - Nextcloud: `backend` + `database`
+  - Synapse: `backend` + `database`
+  - Databases: `database` only (not reachable from frontend)
+- [ ] **2.3** Remove unnecessary `ports` declarations from internal-only services (Ollama:11434, databases)
+- [ ] **2.4** Verify all inter-service communication still works after segmentation
+
+### Phase 3 — Reverse Proxy Integration
+- [ ] **3.1** Add nginx service to `docker-compose.yml`
+- [ ] **3.2** Update `config/nginx/nginx.conf` to cover **all** user-facing services (currently only covers 5 of 15)
+- [ ] **3.3** Add WebSocket upgrade support to nginx config (needed for dashboard terminal, Matrix)
+- [ ] **3.4** Add healthcheck for nginx container
+- [ ] **3.5** Document SSL certificate strategy (placeholders for future Let's Encrypt / self-signed)
+- [ ] **3.6** Update `boom.sh` and `install.sh` to reference nginx as the primary entry point
+- [ ] **3.7** Test full stack with nginx as the single entry point
+
+### Phase 4 — Dashboard Internal Architecture
+- [ ] **4.1** Create `Dashboard/Dashboard1/docs/ARCHITECTURE.md` — internal dashboard architecture:
+  - [ ] Layer diagram: middleware → auth → session → DB → API routes → WebSocket server
+  - [ ] Data model: user schema, session schema, encryption key chain
+  - [ ] API route map with auth requirements per route
+  - [ ] WebSocket ticket flow diagram
+  - [ ] Backup/restore flow
+- [ ] **4.2** Document the entropy key derivation chain visually (HKDF → SESSION_SECRET, WS_SECRET, DB_KEY)
+- [ ] **4.3** Add inline architecture comments to key files (`middleware.ts`, `lib/auth.ts`, `lib/session.ts`)
+
+### Phase 5 — Data Volume Contract
+- [ ] **5.1** Document the `./data/` hierarchy in `docs/ARCHITECTURE.md`:
+  ```
+  data/
+  ├── jellyfin/        # Jellyfin config + cache
+  ├── nextcloud/       # Nextcloud html + data + db
+  ├── matrix/          # Synapse data + config
+  ├── vaultwarden/     # Password vault data
+  ├── open-webui/      # AI chat backend data
+  ├── ollama/          # LLM models
+  ├── kiwix/           # ZIM files + library
+  ├── vpn/             # OpenVPN config + certs
+  ├── workspace/       # Shared workspace (Theia)
+  ├── filebrowser/     # Kiwix manager DB
+  ├── security/        # Dashboard entropy DB
+  └── backups/         # User-initiated backups
+  ```
+- [ ] **5.2** Ensure backup system (`app/api/backup/`) documents what it includes/excludes
+- [ ] **5.3** Add a `data/README.md` or reference in main architecture doc
+
+### Phase 6 — Validation & Cleanup
+- [ ] **6.1** Full stack rebuild: `docker compose down && docker compose up -d`
+- [ ] **6.2** Verify all services reachable through correct paths
+- [ ] **6.3** Run CI: `npm test` in Dashboard, `docker compose config`
+- [ ] **6.4** Remove orphaned or duplicate configs
+- [ ] **6.5** Update `SECURITY.md` if network segmentation changes the attack surface
+
+---
+
+## Out of Scope (Future Issues)
+
+| Item | Reason |
+|---|---|
+| Kubernetes migration | Documented as Phase 3 in Log 21 — not for v0.1.0 |
+| SSL/TLS certificate automation | Requires domain setup, DNS, cert-manager — separate issue |
+| Dashboard microservice split | Intentionally monolithic for v0.1.0 — revisit post-beta |
+| Multi-node / Swarm | Phase 2 (Dokploy) per Log 21 |
+| Mobile app (React Native) | Phase 1 task 43 — separate concern |
+
+---
+
+## Dependencies & Risks
+
+| Risk | Mitigation |
+|---|---|
+| Network segmentation breaks inter-service communication | Test each service after segmentation; keep `depends_on` intact |
+| Nginx config is complex for 15 services | Build incrementally; test each proxy block individually |
+| Removing direct ports breaks existing user workflows | Document port changes clearly in release notes; keep optional direct-access env vars |
+| ADRs become stale | ADRs are append-only; new decisions supersede old ones, never edit |
+
+---
+
+## Acceptance Criteria
+
+- [ ] `docs/ARCHITECTURE.md` exists and covers: system diagram, service catalog, network topology, data flow, security model, deployment model, backup contract
+- [ ] `docs/decisions/` contains at least 6 numbered ADRs
+- [ ] `docker-compose.yml` defines `frontend`, `backend`, `database` networks
+- [ ] Nginx container is in compose and proxies all user-facing services
+- [ ] Database ports (3306, 5432) are NOT exposed to the host
+- [ ] `README.md` links to architecture doc as primary technical reference
+- [ ] Full stack builds and passes health checks
+- [ ] Dashboard tests pass (`npm test`)
+
+---
+
+**Labels:** `type: architecture`, `priority: high`, `scope: project-wide`
+**Assignees:** BasilSuhail, saadsh15
+**Estimate:** Multi-phase — track each phase independently

--- a/.github/ISSUE_TEMPLATE/architecture.md
+++ b/.github/ISSUE_TEMPLATE/architecture.md
@@ -1,0 +1,8 @@
+---
+name: Architecture Improvement
+about: Track architecture-level improvements and refactoring
+title: '[ARCH] '
+labels: 'type: architecture'
+assignees: ''
+
+---

--- a/Project_S_Logs/23_Metrics_UI_Redesign.md
+++ b/Project_S_Logs/23_Metrics_UI_Redesign.md
@@ -370,6 +370,14 @@ From Issue #129 — the #1 user pain point: "tinkering until it breaks, no easy 
 - Container row tooltips — hover any row for full details
 - Null safety — all stat accesses use optional chaining + fallbacks
 
+### PR #149 — Metrics Layout Refinement (70/30)
+**Date:** April 9, 2026 | **Branch:** `metrics/chart-layout`
+
+- CPU chart + Network chart stacked left column (70%)
+- Storage panel full-height right column (30%)
+- Equal chart heights (`h-32`) for visual alignment
+- More space-efficient layout with breathing room
+
 ---
 
 ## Future Work

--- a/Project_S_Logs/27_Dock_UX.md
+++ b/Project_S_Logs/27_Dock_UX.md
@@ -1,0 +1,77 @@
+# Log 27 — Dock UX: Bounce, Floating Windows, Minimize
+
+**Date:** April 9, 2026  
+**Author:** BasilSuhail + Qwen-Coder  
+**PRs:** #156, #157  
+**Issue:** #112 (Dock UX — app launch animation, floating windows)
+
+---
+
+## Overview
+
+Implemented macOS-style dock UX for the HomeForge dashboard sidebar. App icons bounce on launch, show active indicators, and open internal apps (Ollama, Kiwix, Metrics) as floating windows that can be minimized to the dock and restored.
+
+---
+
+## PR #156 — Phase 1: Bounce Animation + Active Dot
+
+### What was built
+
+**Bounce animation:**
+- CSS keyframes: `@keyframes bounce-dock` — 3-cycle translateY animation over 600ms
+- Triggered on dock icon click via React state (`bouncingId`)
+- Auto-resets after animation completes
+
+**Active dot indicator:**
+- Small accent-colored dot below each active sidebar icon
+- Full opacity when app is open, 40% opacity when minimized
+- Hidden when app is closing
+
+### Files Changed
+- `components/dashboard/sidebar.tsx` — bounce state, dot rendering, `handleBounceClick`
+- `app/page.tsx` — `@keyframes bounce-dock` CSS animation
+
+---
+
+## PR #157 — Phase 2: Floating Windows System
+
+### What was built
+
+**Floating windows:**
+- Internal apps (Ollama, Kiwix) open as floating panels over the home dashboard
+- Title bar with app icon, name, minimize (−), and close (×) buttons
+- Home section stays visible behind open windows
+- Multiple windows can be open simultaneously with z-index stacking
+
+**Window management:**
+- `ActiveWindow` interface with `id`, `name`, `icon`, `component`, `zIndex`, `isMinimized`, `isClosing`
+- `openApp()` — opens new window, or restores minimized one, brings to front
+- `closeApp()` — fade-out animation (400ms), then unmounts
+- `minimizeApp()` — hides window, keeps state, shows dot in dock
+- `bringToFront()` — increments z-index, clicked window comes to front
+
+**Dock behavior:**
+- Click dock icon while app is open → minimize to dock
+- Click minimized app → restore and bring to front
+- Click app while closing → reopen immediately
+
+**Layout:**
+- Windows use `top: 16px, bottom: 16px, left: 104px, right: 16px` — edge-to-edge with margins
+- `zIndex: 1000` ensures windows are above all content
+- Content area `overflow-hidden` prevents scroll spillover
+
+### Files Changed
+- `app/page.tsx` — full window management system (open, close, minimize, z-index)
+
+---
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `components/dashboard/sidebar.tsx` | Bounce animation, active dot, dock interaction |
+| `app/page.tsx` | Window state management, floating panels, open/close/minimize |
+
+---
+
+*End of Log 27*

--- a/Project_S_Logs/28_Security_Vite_Upgrade.md
+++ b/Project_S_Logs/28_Security_Vite_Upgrade.md
@@ -1,0 +1,80 @@
+# Log 28 — Security: Vite Dependency Upgrade
+
+**Date:** April 9, 2026  
+**Author:** BasilSuhail + Qwen-Coder  
+**PR:** #170  
+**Issue:** #169
+
+---
+
+## Overview
+
+Upgraded Vite from 7.3.1 to 7.3.2 to resolve 3 Dependabot security alerts. All were development-only vulnerabilities with zero production impact.
+
+---
+
+## Vulnerabilities Fixed
+
+| Alert | Severity | CVE/Reference | Description |
+|---|---|---|---|
+| Arbitrary File Read via WebSocket | High | GHSA-xxxx-xxxx-xxxx | Vite dev server WebSocket could read arbitrary files |
+| `server.fs.deny` bypass | High | GHSA-xxxx-xxxx-xxxx | Query parameters bypass file access restrictions |
+| Path Traversal in `.map` files | Moderate | GHSA-xxxx-xxxx-xxxx | Optimized deps `.map` handling allows path traversal |
+
+---
+
+## Impact Assessment
+
+| Question | Answer |
+|---|---|
+| **Affected environment?** | Development only |
+| **Production at risk?** | No — Next.js 16.2.0 with Turbopack, not Vite |
+| **Users affected?** | None — only developers running `pnpm dev` or `pnpm test:watch` |
+| **Data at risk?** | Local filesystem files accessible to dev machine |
+| **Exploit vector?** | Malicious code in the codebase itself (supply chain) |
+
+---
+
+## Technical Details
+
+**Before:**
+```json
+// package.json
+"devDependencies": {
+  "vitest": "^3.0.0"
+}
+// pnpm-lock.yaml → vite@7.3.1 (transitive via vitest)
+```
+
+**After:**
+```json
+// package.json
+"devDependencies": {
+  "vite": "^7.3.2",
+  "vitest": "^3.0.0"
+}
+// pnpm-lock.yaml → vite@7.3.2
+```
+
+Adding `"vite"` as an explicit devDependency overrides the transitive version pulled by `vitest`, forcing 7.3.2.
+
+---
+
+## Resolution
+
+- Added `"vite": "^7.3.2"` to `devDependencies`
+- Updated `pnpm-lock.yaml` to resolve all vite references to 7.3.2
+- Dependabot alerts #7, #9, #11 will auto-close on merge
+
+---
+
+## Key Files
+
+| File | Change |
+|---|---|
+| `Dashboard/Dashboard1/package.json` | Added `"vite": "^7.3.2"` to devDependencies |
+| `Dashboard/Dashboard1/pnpm-lock.yaml` | Resolved `vite@7.3.1` → `vite@7.3.2` throughout |
+
+---
+
+*End of Log 28*

--- a/Project_S_Logs/29_Architecture_Overhaul.md
+++ b/Project_S_Logs/29_Architecture_Overhaul.md
@@ -1,0 +1,563 @@
+# 29 — Architecture Overhaul
+
+Date: 2026-04-10
+Author: Basil Suhail
+Related Issue: #176
+Branch: `phase-1/architecture-docs`
+
+---
+
+## Context
+
+HomeForge has 15 services orchestrated by Docker Compose, a Next.js 16 dashboard, and 28 implementation logs — but no single document that explains how the system fits together. This log is the first step toward a complete architecture record.
+
+**What this log covers:**
+- Current system state as of April 10, 2026
+- Full service catalog
+- Network topology (current reality)
+- Data flow and security model
+- Data volume structure
+- Deployment lifecycle
+- Architecture Decision Records (ADRs)
+
+---
+
+## 1. System Overview
+
+HomeForge is a self-hosted digital hub. It replaces cloud subscriptions (Google Drive, Office 365, Netflix, 1Password) with self-hosted open-source alternatives running on hardware the user owns — a Raspberry Pi, an old PC, or a VPS.
+
+```
+User's Browser
+    │
+    ▼
+┌─────────────────────────────────────────────────────────┐
+│  Host Machine (macOS / Linux / Raspberry Pi)             │
+│                                                          │
+│  docker-compose.yml (15 services)                       │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐  │
+│  │  Dashboard    │  │  Nextcloud   │  │   Jellyfin   │  │
+│  │  Next.js 16   │  │  :8081       │  │   :8096      │  │
+│  │  :3069/3070   │  │  + Collabora │  │   Media      │  │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘  │
+│         │                 │                  │           │
+│  ┌──────┴───────┐  ┌─────┴────────┐  ┌──────┴───────┐  │
+│  │  Matrix/     │  │  Theia IDE   │  │  Vaultwarden │  │
+│  │  Element     │  │  :3030       │  │  :8083       │  │
+│  │  :8008/8082  │  └──────────────┘  └──────────────┘  │
+│  └──────┬───────┘                                      │
+│         │               ┌─────────────────────────┐     │
+│  ┌──────┴───────┐  ┌───┤  Internal Services      │     │
+│  │  Open-WebUI  │  │   │  (not user-facing)       │     │
+│  │  :8085       │  │   │                          │     │
+│  └──────┬───────┘  │   ├── Ollama :11434          │     │
+│         │          │   ├── MariaDB (Nextcloud)    │     │
+│  ┌──────┴───────┐  │   ├── Postgres (Matrix)      │     │
+│  │  Kiwix       │  │   └── Filebrowser (Kiwix Mgr)│    │
+│  │  :8087/8086  │  │                              │     │
+│  └──────────────┘  └──────────────────────────────┘     │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Core principles:**
+- **Unified** — one login, one dashboard, one update system
+- **Private** — encryption keys the user controls, nothing leaves their network
+- **Modular** — install only what you need, add more later
+- **Simple** — no command line required for day-to-day use
+
+---
+
+## 2. Service Catalog
+
+All 15 services currently defined in `docker-compose.yml`:
+
+### User-Facing Services
+
+| Service | Image | Port | Purpose | Healthcheck |
+|---|---|---|---|---|
+| **Dashboard** | (local build, Next.js 16) | `:3069` (HTTP), `:3070` (WS) | Central control plane — auth, metrics, terminal, backup | Custom fetch to `:3069` |
+| **Jellyfin** | `jellyfin/jellyfin:10.10.6` | `:8096` | Media server — video, music, photos | `curl :8096/health` |
+| **Nextcloud** | `nextcloud:30` | `:8081` | Files, calendar, contacts, docs | `curl /status.php` |
+| **Collabora** | `collabora/code:24.04.10.2.1` | `:9980` | Document editing (WOPI server for Nextcloud Office) | `curl :9980/` |
+| **Theia IDE** | `ghcr.io/eclipse-theia/theia-ide:latest` | `:3030` | Browser-based IDE with terminal and Docker access | Node HTTP check |
+| **Matrix Synapse** | `matrixdotorg/synapse:v1.120.0` | `:8008` | Self-hosted encrypted chat server | `curl /health` |
+| **Element** | `vectorim/element-web:v1.11.90` | `:8082` | Matrix web client | None |
+| **Vaultwarden** | `vaultwarden/server:1.32.7` | `:8083` | Password manager (Bitwarden-compatible) | `curl /alive` |
+| **Open-WebUI** | `ghcr.io/open-webui/open-webui:0.8.12` | `:8085` | Local AI chat interface | `curl :8080/` |
+| **Kiwix Reader** | `ghcr.io/kiwix/kiwix-serve:3.7.0` | `:8087` | Offline knowledge base (Wikipedia via ZIM files) | None |
+| **Kiwix Manager** | `filebrowser/filebrowser:v2.31.2` | `:8086` | File browser for uploading ZIM files to Kiwix | None |
+| **OpenVPN** | `d3vilh/openvpn-server:latest` | `:1194/udp` | Self-hosted VPN server | None |
+| **OpenVPN UI** | `d3vilh/openvpn-ui:latest` | `:8090` | VPN management web UI | None |
+
+### Internal Services (Not Directly User-Facing)
+
+| Service | Image | Purpose | Dependencies |
+|---|---|---|---|
+| **MariaDB** | `mariadb:10.11` | Nextcloud database | None (data volume: `./data/nextcloud/db`) |
+| **Synapse DB** | `postgres:15-alpine` | Matrix Synapse database | None (data volume: `./data/matrix/db`) |
+| **Ollama** | `ollama/ollama:0.20.0` | Local LLM inference engine | None (data volume: `./data/ollama`) |
+
+### Service Dependencies
+
+```
+dashboard → jellyfin, nextcloud
+nextcloud → db (service_started), collabora (service_healthy)
+open-webui → ollama (service_healthy)
+synapse → synapse-db
+openvpn-ui → openvpn
+```
+
+---
+
+## 3. Network Topology (Current State)
+
+**As of April 10, 2026:** All services share a single default Docker Compose network. There is no segmentation. Every container can reach every other container.
+
+```
+Default Docker Network (flat)
+├── project-s-dashboard     (:3069, :3070)
+├── project-s-jellyfin      (:8096)
+├── project-s-nextcloud     (:8081)
+├── project-s-nextcloud-db  (internal, MariaDB)
+├── project-s-collabora     (:9980)
+├── project-s-theia         (:3030)
+├── project-s-matrix-server  (:8008)
+├── project-s-matrix-db      (internal, Postgres)
+├── project-s-matrix-client  (:8082)
+├── project-s-vaultwarden    (:8083)
+├── project-s-open-webui    (:8085)
+├── project-s-ollama        (:11434)
+├── project-s-kiwix-reader  (:8087)
+├── project-s-kiwix-manager (:8086)
+├── project-s-openvpn       (:1194/udp)
+└── project-s-openvpn-ui    (:8090)
+```
+
+**Problems with current topology:**
+1. Databases (MariaDB, Postgres) are reachable from every service — no isolation
+2. Ollama's port 11434 is exposed to the host — only Open-WebUI needs it
+3. Nginx reverse proxy config exists (`config/nginx/nginx.conf`) but is NOT in the compose stack
+4. No network boundaries between public-facing and internal services
+
+**Target topology (planned for Phase 2):**
+```
+frontend network  — nginx, dashboard, element, openvpn-ui, kiwix-manager, open-webui
+backend network   — jellyfin, nextcloud, collabora, theia, synapse, vaultwarden, kiwix, ollama, openvpn
+database network  — db (MariaDB), synapse-db (Postgres)
+```
+
+---
+
+## 4. Data Flow
+
+### User Request Flow
+
+```
+User browser
+    │
+    ▼
+http://<LAN_IP>:<service_port>     ← Direct port access (no reverse proxy yet)
+    │
+    ▼
+Docker Compose port mapping
+    │
+    ▼
+Target container (e.g., nextcloud:80, jellyfin:8096)
+    │
+    ▼
+Service responds
+    │
+    ▼
+CSP headers set by docker-compose or nginx (partial)
+    │
+    ▼
+Dashboard may iframe the service (Jellyfin, Nextcloud, Element sections)
+```
+
+### Dashboard Request Flow
+
+```
+User → Dashboard (:3069)
+    │
+    ├── middleware.ts — checks iron-session cookie, redirects to /login if unauthenticated
+    ├── /login — Argon2id password verification against SQLCipher DB
+    ├── /setup — one-time entropy key generation + admin account creation
+    ├── /api/* — API routes (auth, backup, kiwix, ollama, stats)
+    ├── /kiwix/* — Kiwix content proxy
+    └── WebSocket (:3070) — terminal PTY sessions (ticket-authenticated)
+```
+
+### Authentication Flow
+
+```
+First-time setup:
+1. User opens :3069 → redirected to /setup
+2. Mouse movement entropy → 128-char hex key (SHA-512 via Web Crypto API)
+3. User creates admin account (username + password)
+4. Password hashed with Argon2id (64 MiB memory, 3 iterations)
+5. HKDF-SHA512 derives SESSION_SECRET, WS_SECRET, DB_KEY from entropy key
+6. Database rekeyed from temporary UUID key to entropy-derived DB_KEY
+7. Session cookie set (iron-session, HTTP-only, signed)
+
+Subsequent logins:
+1. User submits username + password
+2. Argon2id hash compared against SQLCipher DB
+3. On success: iron-session cookie set
+4. All API routes check session via middleware
+5. WebSocket terminal requires short-lived HMAC ticket from /api/auth/ws-ticket
+```
+
+---
+
+## 5. Security Model
+
+### Encryption at Rest
+
+| Component | Encryption | Key Source |
+|---|---|---|
+| Dashboard user DB (SQLite) | AES-256-GCM (SQLCipher) | HKDF-derived DB_KEY from entropy key |
+| iron-session cookie | AES-256-GCM + HMAC | HKDF-derived SESSION_SECRET |
+| WebSocket tickets | HMAC-SHA256 | HKDF-derived WS_SECRET, 30s expiry |
+| User passwords | Argon2id | One-way hash, never stored |
+
+### Secrets Management
+
+**Runtime secrets (never written to disk):**
+- `SESSION_SECRET` — derived from entropy key at startup
+- `WS_SECRET` — derived from entropy key at startup
+- `DB_KEY` — derived from entropy key at startup
+
+**Infrastructure secrets (stored in `.env`, not committed):**
+
+| Variable | Used By | Generation |
+|---|---|---|
+| `MYSQL_ROOT_PASSWORD` | Nextcloud MariaDB | `openssl rand -hex 32` |
+| `MYSQL_PASSWORD` | Nextcloud MariaDB | `openssl rand -hex 32` |
+| `NEXTCLOUD_ADMIN_PASSWORD` | Nextcloud admin | User-defined |
+| `COLLABORA_PASSWORD` | Collabora Online admin | `openssl rand -hex 32` |
+| `MATRIX_REGISTRATION_SECRET` | Synapse federation | `openssl rand -hex 32` |
+| `MATRIX_MACAROON_SECRET_KEY` | Synapse macaroon tokens | `openssl rand -hex 32` |
+| `MATRIX_FORM_SECRET` | Synapse CSRF | `openssl rand -hex 32` |
+| `WEBUI_SECRET_KEY` | Open-WebUI session | `openssl rand -base64 32` |
+| `VPN_ADMIN_PASSWORD` | OpenVPN UI admin | User-defined |
+
+### Rate Limiting
+
+- Login endpoint: 10 attempts per username per 15 minutes (sliding window)
+- Returns `X-RateLimit-*` headers
+
+### Container Security
+
+| Service | Privileged | Capabilities | Notes |
+|---|---|---|---|
+| Dashboard | No (runs as root in container) | None | Mounts `/var/run/docker.sock` |
+| Theia IDE | Yes | MKNOD, SYS_ADMIN | Full Docker access for development |
+| OpenVPN | Yes | NET_ADMIN | Required for TUN/TAP device |
+| OpenVPN UI | Yes | None | Mounts Docker socket for container management |
+| Collabora | No | MKNOD, SYS_ADMIN (seccomp:unconfined) | Required for document rendering |
+
+---
+
+## 6. Data Volume Structure
+
+All persistent data lives under `./data/` on the host:
+
+```
+data/
+├── jellyfin/
+│   ├── config/          # Jellyfin configuration
+│   └── cache/           # Transcoded media cache
+├── nextcloud/
+│   ├── html/            # Nextcloud web root
+│   ├── data/            # User files (Nextcloud data dir)
+│   └── db/              # MariaDB database files
+├── matrix/
+│   ├── db/              # Postgres data (Synapse DB volume)
+│   └── synapse/         # Synapse homeserver data
+├── vaultwarden/         # Password vault data
+├── open-webui/          # Open-WebUI backend data
+├── ollama/              # LLM models
+├── kiwix/               # ZIM files + library.xml
+├── vpn/                 # OpenVPN config, certs, PKI
+│   ├── db/              # OpenVPN UI database
+│   └── pki/             # Easy-RSA PKI
+├── workspace/           # Shared workspace (Theia IDE)
+├── filebrowser/         # Kiwix manager database
+├── security/            # Dashboard entropy-encrypted user DB
+└── backups/             # User-initiated backups
+```
+
+**Mount types:**
+- Named bind mounts from host `./data/` → container paths
+- Dashboard mounts `./data` as read-only (`:ro`) for metrics
+- Dashboard mounts `./data/security` and `./data/backups` as read-write
+- Theia mounts `/var/run/docker.sock` for container management
+- OpenVPN UI mounts `/var/run/docker.sock` as read-only
+
+---
+
+## 7. Deployment Lifecycle
+
+### First-Time Setup (install.sh)
+
+```
+1. chmod +x install.sh
+2. ./install.sh
+   ├── Auto-detects LAN IP (hostname -I / ipconfig getifaddr)
+   ├── Creates .env from .env.example with secure defaults
+   ├── docker compose up -d
+   ├── Installs Nextcloud Hub apps (Calendar, Contacts, Office, Talk)
+   ├── Configures Nextcloud Office (Collabora) via occ commands
+   └── Opens browser to dashboard URL
+```
+
+### Subsequent Starts (boom.sh)
+
+```
+1. chmod +x boom.sh
+2. ./boom.sh
+   ├── Reads existing .env
+   ├── Auto-detects LAN IP
+   ├── docker compose up -d
+   └── Opens browser to dashboard URL
+```
+
+### Shutdown
+
+```
+docker compose down
+```
+
+### Dashboard One-Time Setup (First Launch)
+
+```
+1. Open http://localhost:3069
+2. Redirected to /setup automatically
+3. Generate entropy key (mouse movement + CSPRNG)
+4. Create admin account
+5. Database encrypted and rekeyed
+6. Redirected to dashboard
+```
+
+---
+
+## 8. Architecture Decision Records
+
+### ADR-0001: Use Docker Compose Over Kubernetes
+
+**Status:** Accepted
+**Date:** 2026-04-04
+**Source:** Log 21 — Kubernetes vs. Docker Orchestration Audit
+
+**Context:** HomeForge is a packaged product for end-users installing on their own servers, mini-PCs, or Raspberry Pi clusters. We evaluated K3s/K8s vs Docker Compose.
+
+**Decision:** Retain Docker Compose as the primary orchestration engine for MVP and V1.
+
+**Rationale:**
+- Kubernetes introduces operational overhead (networking, storage, ingress) conflicting with the "simple install" goal
+- Industry precedent: TrueNAS SCALE 24.10 "Electric Eel" reverted from K3s back to Docker Compose for home users
+- K3s requires 5x–10x idle RAM overhead vs native Docker — detrimental to low-power hardware
+- Docker Compose is pre-installed on most server distributions; K3s requires additional setup
+- TrueNAS found the UI-to-K8s middleware layer was the primary source of bugs
+
+**Consequences:**
+- Simpler installation: one command (`./boom.sh`) and everything works
+- Single `docker-compose.yml` users can read to understand every service
+- Debug with `docker logs <name>` — no cluster knowledge required
+- Upgrade by changing one image tag
+- Multi-node support deferred to Phase 2 (Dokploy per Log 21)
+
+**Future:** A `Driver` abstraction layer will be implemented so the UI talks to `OrchestrationDriver`, enabling a `KubernetesDriver` later without rewriting the dashboard.
+
+---
+
+### ADR-0002: Entropy-Based Authentication with HKDF Key Derivation
+
+**Status:** Accepted
+**Date:** 2026-04-10
+**Source:** Log 24 — Authentication System
+
+**Context:** Users need a single master key that encrypts their entire installation. The key must be unpredictable, never transmitted, and never stored in plaintext.
+
+**Decision:** Mouse movement entropy + CSPRNG → SHA-512 → HKDF-SHA512 → SESSION_SECRET, WS_SECRET, DB_KEY.
+
+**Rationale:**
+- Mouse movement provides genuine entropy from user interaction
+- CSPRNG (crypto.getRandomValues) seeds the pool for additional unpredictability
+- SHA-512 hashes raw entropy into a uniform 128-character hex key
+- HKDF-SHA512 derives three independent secrets — none can be computed from the others
+- Runtime secrets are derived at startup, never written to disk or .env
+
+**Key derivation chain:**
+```
+User mouse movement + CSPRNG
+    │
+    ▼
+SHA-512 → 128-char hex entropy key
+    │
+    ▼
+HKDF-SHA512 (with unique info strings)
+    ├──→ SESSION_SECRET (iron-session cookie encryption)
+    ├──→ WS_SECRET (WebSocket ticket HMAC)
+    └──→ DB_KEY (SQLCipher AES-256-GCM encryption)
+```
+
+**Consequences:**
+- User MUST save entropy key — it cannot be recovered if lost
+- No password reset flow exists — losing the key means losing the database
+- All credentials protected by Argon2id (64 MiB memory, 3 iterations)
+- Session cookie is HTTP-only, signed, encrypted (iron-session v8)
+
+---
+
+### ADR-0003: SQLCipher for User Database Encryption at Rest
+
+**Status:** Accepted
+**Date:** 2026-04-10
+
+**Context:** The dashboard needs a user database (accounts, sessions, roles). Must be encrypted at rest, lightweight, and work on a single node.
+
+**Decision:** Use SQLCipher via `better-sqlite3-multiple-ciphers` for the user database.
+
+**Rationale:**
+- SQLite is zero-config, single-file, no separate database container needed
+- SQLCipher adds AES-256-GCM encryption transparently
+- `better-sqlite3-multiple-ciphers` provides synchronous Node.js bindings
+- Pre/post-setup rekey: opens with temporary UUID key, then `PRAGMA rekey` to entropy-derived key
+- Fits the single-node, low-overhead design
+
+**Consequences:**
+- Database file is unreadable without the entropy-derived DB_KEY
+- No backup/restore complexity of a separate database server
+- Single file makes backup trivial (copy the file)
+- Limited to single-writer — acceptable for user management workload
+
+---
+
+### ADR-0004: Dashboard as Central Control Plane
+
+**Status:** Accepted
+**Date:** 2026-04-10
+
+**Context:** Users need a single interface to monitor, manage, and interact with all services.
+
+**Decision:** Build a single Next.js 16 application as the central control plane — monolithic by design.
+
+**Rationale:**
+- One codebase, one deploy, one login
+- Next.js API routes handle all backend logic without a separate API service
+- WebSocket server runs alongside Next.js on port 3070
+- Dashboard mounts Docker socket to monitor all containers
+- Dashboard mounts `./data` as read-only for metrics collection
+- Fits the "one dashboard, one login" product principle
+
+**What the dashboard does:**
+- Authentication and session management (iron-session, Argon2id, SQLCipher)
+- Server resource metrics (CPU, RAM, disk via Docker API)
+- Service health monitoring
+- WebSocket terminal access to containers
+- Backup/restore orchestration
+- Kiwix ZIM file management proxy
+- Ollama model management proxy
+- Module launching (iframe embeds for Jellyfin, Nextcloud, Element, etc.)
+
+**Consequences:**
+- Monolith is intentional — no microservice split for v0.1.0
+- Dashboard is the single point of failure for auth and management
+- All dashboard logic documented in `Dashboard/Dashboard1/docs/ARCHITECTURE.md` (to be created)
+
+---
+
+### ADR-0005: Nginx Reverse Proxy for All User-Facing Services
+
+**Status:** Planned (not yet implemented)
+**Date:** 2026-04-10
+
+**Context:** 15 services expose raw ports directly to the host. No SSL, no centralized CSP headers, no unified routing. An nginx config exists in `config/nginx/nginx.conf` but is not in the compose stack.
+
+**Decision:** Add nginx as a container in docker-compose.yml and make it the single entry point for all user-facing services.
+
+**Rationale:**
+- Centralizes SSL termination (future Let's Encrypt support)
+- Single CSP header management point
+- Clean URLs (e.g., `homeforge.local/media` instead of `:8096`)
+- WebSocket upgrade support for dashboard terminal and Matrix
+- Industry standard for reverse proxying
+
+**Current state:** `config/nginx/nginx.conf` exists with proxy blocks for 5 of 15 services. Not wired into compose.
+
+**Planned:** Full nginx config covering all user-facing services, WebSocket upgrade support, healthcheck, documented SSL placeholder strategy.
+
+---
+
+### ADR-0006: Flat Data Volume Structure Under ./data/
+
+**Status:** Accepted (documenting current reality)
+**Date:** 2026-04-10
+
+**Context:** Each service needs persistent storage. We chose a flat `./data/<service-name>/` structure.
+
+**Decision:** All service data lives under a single `./data/` directory on the host, with one subdirectory per service.
+
+**Rationale:**
+- Simple to understand: one directory, all your data
+- Simple to back up: archive `./data/` and you have everything
+- Simple to migrate: copy the directory, everything works
+- No complex volume naming or Docker volume management
+- Dashboard mounts `./data` read-only for metrics across all services
+
+**Consequences:**
+- All data is in one place — easy backup, easy understanding
+- No separation between config, state, and user data within each service directory
+- Backup system (`app/api/backup/`) depends on this structure
+- Future network segmentation and access control must account for shared mount points
+
+---
+
+## 9. Known Issues & Technical Debt
+
+| Issue | Severity | Notes |
+|---|---|---|
+| Nginx not in compose stack | High | `config/nginx/nginx.conf` exists but unused |
+| Flat network — no segmentation | High | All containers can reach all others |
+| Database ports exposed to host | Medium | MariaDB and Postgres should be internal-only |
+| Ollama port 11434 exposed to host | Low | Only Open-WebUI needs it |
+| No SSL/TLS | Medium | All traffic is HTTP on LAN |
+| OpenVPN restart set to "no" | Low | Known issue on Docker Desktop for Mac (Log 25) |
+| Dashboard runs as root | Medium | Required for Docker socket access |
+| Theia IDE privileged mode | Low | Required for Docker-in-Docker development |
+
+---
+
+## 10. What Needs to Change (Future Phases)
+
+### Phase 2 — Network Segmentation
+- Three networks: `frontend`, `backend`, `database`
+- Remove host ports from internal-only services
+- Database isolation
+
+### Phase 3 — Reverse Proxy Integration
+- Add nginx to compose
+- Complete proxy config for all 15 services
+- WebSocket upgrade support
+- SSL certificate strategy
+
+### Phase 4 — Dashboard Internal Architecture
+- `Dashboard/Dashboard1/docs/ARCHITECTURE.md`
+- Layer diagram: middleware → auth → session → DB → API → WebSocket
+- API route map with auth requirements
+- WebSocket ticket flow
+
+### Phase 5 — Data Volume Contract
+- Documented backup inclusion/exclusion list
+- Data hierarchy reference
+- Mount type documentation (ro vs rw)
+
+### Phase 6 — Validation
+- Full stack rebuild
+- CI verification
+- Cleanup of orphaned configs
+
+---
+
+**Status:** Living document. Updated as architecture evolves.
+**Next Update:** After Phase 2 (network segmentation) implementation.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - [Contributors](#contributors)
 
 **Project Overview**
+- [Architecture](Project_S_Logs/29_Architecture_Overhaul.md)
 - [What is it?](#what-is-it)
 - [Core Features](#core-features)
 - [How it Works](#how-it-works)
@@ -153,9 +154,15 @@ To add more applications to the ecosystem:
 
 ## 📝 Project Documentation & Logs
 
+**Architecture** — Start here to understand the entire system:
+- [Architecture Overhaul](Project_S_Logs/29_Architecture_Overhaul.md) — system diagram, service catalog, network topology, security model, deployment lifecycle
+- [Architecture Decision Records](docs/decisions/) — numbered records for every major architectural decision
+
+**Implementation Logs:**
+
 | Resource | Location |
 |---|---|
-| Technical logs | `Project_S_Logs/` directory |
+| Technical logs (01–28) | `Project_S_Logs/` directory |
 | Static UI preview | `Project_S_Logs/06_Dashboard_Technical_Report.html` |
 
 Open the HTML file in any browser for a functional, high-fidelity mirror of the dashboard frontend.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,82 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---|---|
+| `main` (pre-alpha) | ✅ Yes |
+| Earlier releases | ❌ No |
+
+---
+
+## Reporting a Vulnerability
+
+We take security seriously. If you discover a vulnerability in HomeForge, please report it **privately** so we can investigate and fix it before public disclosure.
+
+### How to Report
+
+Send an email with details of the vulnerability to:
+
+- **Basil Suhail** — [basilsuhail3@gmail.com](mailto:basilsuhail3@gmail.com)
+- **Saad Shafique** — [shafiquesaad15@gmail.com](mailto:shafiquesaad15@gmail.com)
+
+### What to Include
+
+1. **Description** — Clear explanation of the vulnerability
+2. **Steps to Reproduce** — Specific commands, configs, or actions that trigger it
+3. **Affected Component** — Which service, API route, or dependency is impacted
+4. **Severity** — Your assessment (Low / Medium / High / Critical)
+5. **Proof of Concept** — Code, screenshots, or logs (if applicable)
+
+### What to Expect
+
+| Stage | Timeline |
+|---|---|
+| Acknowledgment | Within 72 hours |
+| Initial investigation | Within 1 week |
+| Fix deployed | Within 4 weeks (depending on severity) |
+| Public disclosure | After fix is released, or 90 days — whichever comes first |
+
+We will keep you informed of our progress. You are welcome to request an update at any time.
+
+---
+
+## Scope
+
+### In Scope
+
+- Authentication system (entropy key, session management, RBAC)
+- SQLCipher database encryption
+- WebSocket terminal security (ticket auth, PTY isolation)
+- Docker container security (volume mounts, privileged mode usage)
+- Dependency vulnerabilities (Dependabot alerts)
+- API route access controls
+
+### Out of Scope
+
+- Third-party services bundled with HomeForge (Jellyfin, Nextcloud, Matrix, etc.) — report to upstream maintainers
+- Vulnerabilities requiring physical access to the host machine
+- Social engineering attacks
+- Denial of service via resource exhaustion (rate limiting is in place)
+
+---
+
+## Safe Harbor
+
+We will not pursue legal action against security researchers who:
+
+- Follow this policy in good faith
+- Do not access, modify, or delete user data
+- Do not disrupt services for other users
+- Report the vulnerability promptly and privately
+
+---
+
+## Known Issues
+
+- OpenVPN container fails to start on Docker Desktop for Mac due to iptables/`eth0` incompatibility — documented in Log 25
+- This is a known limitation, not a security vulnerability
+
+---
+
+*Last updated: April 10, 2026*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   jellyfin:
     image: jellyfin/jellyfin:10.10.6
     container_name: project-s-jellyfin
+    networks:
+      - backend
     ports:
       - '8096:8096'
     volumes:
@@ -27,6 +29,9 @@ services:
     container_name: project-s-dashboard
     hostname: homeforge-dashboard
     user: root
+    networks:
+      - frontend
+      - backend
     ports:
       - '3069:3069'
       - '3070:3070'
@@ -53,6 +58,8 @@ services:
   db:
     image: mariadb:10.11
     container_name: project-s-nextcloud-db
+    networks:
+      - database
     command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     restart: always
     volumes:
@@ -70,6 +77,9 @@ services:
   nextcloud:
     image: nextcloud:30
     container_name: project-s-nextcloud
+    networks:
+      - backend
+      - database
     restart: always
     ports:
       - '8081:80'
@@ -112,6 +122,8 @@ services:
   collabora:
     image: collabora/code:24.04.10.2.1
     container_name: project-s-collabora
+    networks:
+      - backend
     restart: unless-stopped
     ports:
       - '9980:9980'
@@ -147,6 +159,8 @@ services:
   theia:
     image: ghcr.io/eclipse-theia/theia-ide/theia-ide:latest  # Theia only publishes :latest on GHCR
     container_name: project-s-theia
+    networks:
+      - backend
     # Theia requires root + privileged for Docker integration features
     # (container management, terminal with Docker access)
     user: root
@@ -175,6 +189,8 @@ services:
   synapse-db:
     image: postgres:15-alpine  # data volume was initialized with PG15 — do NOT bump without pg_upgrade
     container_name: project-s-matrix-db
+    networks:
+      - database
     environment:
       - POSTGRES_USER=${MATRIX_DB_USER}
       - POSTGRES_PASSWORD=${MATRIX_DB_PASSWORD}
@@ -187,6 +203,9 @@ services:
   synapse:
     image: matrixdotorg/synapse:v1.120.0
     container_name: project-s-matrix-server
+    networks:
+      - backend
+      - database
     depends_on:
       - synapse-db
     ports:
@@ -216,6 +235,8 @@ services:
   element:
     image: vectorim/element-web:v1.11.90
     container_name: project-s-matrix-client
+    networks:
+      - frontend
     ports:
       - '8082:80'
     volumes:
@@ -225,6 +246,8 @@ services:
   vaultwarden:
     image: vaultwarden/server:1.32.7
     container_name: project-s-vaultwarden
+    networks:
+      - backend
     ports:
       - '8083:80'
     volumes:
@@ -243,6 +266,9 @@ services:
   open-webui:
     image: ghcr.io/open-webui/open-webui:0.8.12
     container_name: project-s-open-webui
+    networks:
+      - frontend
+      - backend
     ports:
       - '8085:8080'
     volumes:
@@ -275,8 +301,8 @@ services:
   ollama:
     image: ollama/ollama:0.20.0
     container_name: project-s-ollama
-    ports:
-      - '11434:11434'
+    networks:
+      - backend
     volumes:
       - ./data/ollama:/root/.ollama
       - ./data/workspace:/workspace
@@ -299,6 +325,8 @@ services:
   kiwix:
     image: ghcr.io/kiwix/kiwix-serve:3.7.0
     container_name: project-s-kiwix-reader
+    networks:
+      - backend
     ports:
       - '8087:8080'
     volumes:
@@ -318,6 +346,8 @@ services:
     image: filebrowser/filebrowser:v2.31.2
     container_name: project-s-kiwix-manager
     user: "${UID:-1000}:${GID:-1000}"
+    networks:
+      - frontend
     ports:
       - '8086:80'
     volumes:
@@ -329,6 +359,8 @@ services:
   openvpn:
     image: d3vilh/openvpn-server:latest
     container_name: project-s-openvpn
+    networks:
+      - backend
     privileged: true
     cap_add:
       - NET_ADMIN
@@ -336,11 +368,13 @@ services:
       - '1194:1194/udp'
     volumes:
       - ./data/vpn:/etc/openvpn
-    restart: unless-stopped
+    restart: "no"
 
   openvpn-ui:
     image: d3vilh/openvpn-ui:latest
     container_name: project-s-openvpn-ui
+    networks:
+      - frontend
     privileged: true
     depends_on:
       - openvpn
@@ -355,3 +389,11 @@ services:
       - ./data/vpn/pki:/usr/share/easy-rsa/pki
       - /var/run/docker.sock:/var/run/docker.sock:ro
     restart: unless-stopped
+
+networks:
+  frontend:
+    driver: bridge
+  backend:
+    driver: bridge
+  database:
+    driver: bridge

--- a/docs/decisions/0001-docker-compose-over-kubernetes.md
+++ b/docs/decisions/0001-docker-compose-over-kubernetes.md
@@ -1,0 +1,44 @@
+# ADR-0001: Use Docker Compose Over Kubernetes
+
+**Status:** Accepted
+**Date:** 2026-04-04
+**Source:** Log 21 — Kubernetes vs. Docker Orchestration Audit
+
+## Context
+
+HomeForge is a packaged product for end-users installing on their own servers, mini-PCs, or Raspberry Pi clusters. We evaluated K3s/Kubernetes vs Docker Compose as the orchestration layer.
+
+Key considerations:
+- Installation simplicity (one command: `./boom.sh`)
+- Resource efficiency on low-power hardware (Raspberry Pi, N100 mini-PCs)
+- Maintenance burden for users with no DevOps background
+- Industry trends in the home server space
+
+## Decision
+
+Retain Docker Compose as the primary orchestration engine for HomeForge MVP and V1. Kubernetes migration is deferred to Phase 3 (planned as a driver abstraction, not a full rewrite).
+
+## Rationale
+
+1. **Complexity tax** — Kubernetes introduces significant operational overhead (networking, storage, ingress) that conflicts with the "simple install" goal
+2. **Industry precedent** — TrueNAS SCALE 24.10 "Electric Eel" reverted from K3s back to Docker Compose for home users; the UI-to-K8s middleware was the primary source of bugs
+3. **Resource efficiency** — K3s requires 5x–10x idle RAM overhead vs native Docker, detrimental to low-power hardware
+4. **Installation friction** — Docker Compose is pre-installed on most server distributions; K3s requires additional setup, kernel modules, and port management
+5. **Debugging barrier** — `docker logs <name>` vs `kubectl logs` — the former requires no cluster knowledge
+
+## Consequences
+
+**Positive:**
+- One command installs everything
+- Single `docker-compose.yml` explains every service
+- Debug with `docker logs` — no cluster knowledge required
+- Upgrade by changing one image tag
+
+**Negative:**
+- No multi-node support (deferred to Phase 2 via Dokploy)
+- No self-healing or automated scaling
+- Manual service dependency management via `depends_on`
+
+## Future
+
+A `Driver` abstraction will be implemented: UI talks to `OrchestrationDriver`, initial implementation is `DockerComposeDriver`, `KubernetesDriver` can be added later without rewriting the dashboard.

--- a/docs/decisions/0002-entropy-auth-hkdf.md
+++ b/docs/decisions/0002-entropy-auth-hkdf.md
@@ -1,0 +1,57 @@
+# ADR-0002: Entropy-Based Authentication with HKDF Key Derivation
+
+**Status:** Accepted
+**Date:** 2026-04-10
+**Source:** Log 24 — Authentication System
+
+## Context
+
+Users need a single master key that encrypts their entire HomeForge installation. The key must be unpredictable, never transmitted over the network, and never stored in plaintext.
+
+## Decision
+
+Mouse movement entropy combined with CSPRNG, hashed via SHA-512, produces a 128-character hex key. HKDF-SHA512 derives three independent secrets: `SESSION_SECRET`, `WS_SECRET`, `DB_KEY`.
+
+## Key Derivation Chain
+
+```
+User mouse movement + CSPRNG (window.crypto.getRandomValues)
+    │
+    ▼
+SHA-512 → 128-char hex entropy key
+    │
+    ▼
+HKDF-SHA512 (with unique info strings)
+    ├──→ SESSION_SECRET  (iron-session cookie encryption)
+    ├──→ WS_SECRET        (WebSocket ticket HMAC-SHA256)
+    └──→ DB_KEY           (SQLCipher AES-256-GCM)
+```
+
+## Rationale
+
+1. Mouse movement provides genuine, unpredictable entropy from user interaction
+2. CSPRNG seeds the pool for additional cryptographic strength
+3. SHA-512 hashes raw entropy into a uniform distribution
+4. HKDF derives three independent secrets — compromise of one does not reveal the others
+5. Runtime secrets are derived at startup, never written to disk or `.env`
+
+## Consequences
+
+**Positive:**
+- No secrets on disk — all three derived at runtime
+- Each installation is cryptographically unique
+- iron-session cookies are HTTP-only, signed, encrypted (AES-256-GCM)
+- User passwords hashed with Argon2id (64 MiB memory, 3 iterations)
+
+**Negative:**
+- User MUST save the entropy key — it cannot be recovered if lost
+- No password reset flow exists — losing the key means losing the user database
+- First-time setup requires ~10 seconds of mouse movement
+
+## Implementation
+
+- Web Crypto API on the frontend for entropy collection
+- `iron-session` v8 for session management
+- `better-sqlite3-multiple-ciphers` for encrypted SQLite
+- `argon2` package for password hashing
+- Sliding-window rate limiter on login: 10 attempts per username per 15 minutes

--- a/docs/decisions/0003-sqlcipher-user-db.md
+++ b/docs/decisions/0003-sqlcipher-user-db.md
@@ -1,0 +1,44 @@
+# ADR-0003: SQLCipher for User Database Encryption at Rest
+
+**Status:** Accepted
+**Date:** 2026-04-10
+
+## Context
+
+The dashboard needs a user database for accounts, sessions, and roles. Requirements:
+- Encrypted at rest
+- Lightweight (single-node, no separate database container)
+- Simple backup/restore
+- Compatible with Node.js
+
+## Decision
+
+Use SQLCipher via the `better-sqlite3-multiple-ciphers` npm package.
+
+## Rationale
+
+1. SQLite is zero-config, single-file — no separate database container needed
+2. SQLCipher adds AES-256-GCM encryption transparently
+3. `better-sqlite3-multiple-ciphers` provides synchronous Node.js bindings
+4. Pre/post-setup rekey: database opens with a temporary UUID-derived key, then `PRAGMA rekey` transitions to the entropy-derived key after setup completes
+5. Single file makes backup trivial (copy the file)
+
+## Consequences
+
+**Positive:**
+- Database file is unreadable without the entropy-derived `DB_KEY`
+- No backup/restore complexity of a separate database server
+- Single file backup — copy `data/security/homeforge.db`
+- Fits the single-node, low-overhead design
+
+**Negative:**
+- Limited to single-writer — acceptable for user management workload
+- Not suitable for high-concurrency (but HomeForge is single-user/few-user)
+- Requires `better-sqlite3-multiple-ciphers` (fork of `better-sqlite3`) — must track upstream updates
+
+## Implementation
+
+- Database location: `./data/security/homeforge.db` (encrypted)
+- Pre-setup: opens with temporary UUID-derived key
+- Post-setup: `PRAGMA rekey` to entropy-derived `DB_KEY`
+- User schema: id, username, password_hash (Argon2id), role (admin/viewer), created_at

--- a/docs/decisions/0004-dashboard-monolith.md
+++ b/docs/decisions/0004-dashboard-monolith.md
@@ -1,0 +1,50 @@
+# ADR-0004: Dashboard as Central Control Plane
+
+**Status:** Accepted
+**Date:** 2026-04-10
+
+## Context
+
+Users need a single interface to monitor, manage, and interact with all HomeForge services. We needed to decide between a monolithic dashboard vs. separate microservices for auth, metrics, terminal, etc.
+
+## Decision
+
+Build a single Next.js 16 application as the central control plane — monolithic by design. No microservice split for v0.1.0.
+
+## Rationale
+
+1. One codebase, one deploy, one login — aligns with "one dashboard, one login" product principle
+2. Next.js API routes handle all backend logic without a separate API service
+3. WebSocket server runs alongside Next.js on port 3070 — same process, shared state
+4. Dashboard mounts Docker socket to monitor all containers — no separate agent needed
+5. Dashboard mounts `./data` as read-only for metrics collection across all services
+
+## What the Dashboard Does
+
+| Responsibility | Implementation |
+|---|---|
+| Authentication | iron-session, Argon2id, SQLCipher, entropy key |
+| Session management | HTTP-only encrypted cookies, middleware guards |
+| Server metrics | Docker API via `/var/run/docker.sock` mount |
+| Service health | Poll container healthchecks |
+| Terminal | WebSocket PTY via `node-pty`, ticket-authenticated |
+| Backup/restore | Orchestrate `docker compose` commands |
+| Kiwix proxy | Proxy ZIM file browsing and management |
+| Ollama proxy | Proxy model management and inference |
+| Module launching | iframe embeds for Jellyfin, Nextcloud, Element, etc. |
+
+## Consequences
+
+**Positive:**
+- Single deployment to manage
+- Shared state between auth, metrics, terminal — no inter-service calls
+- Simple to debug: one application, one log stream
+
+**Negative:**
+- Dashboard is the single point of failure for auth and management
+- Large codebase — harder to isolate bugs
+- All dashboard logic must be documented internally (`Dashboard/Dashboard1/docs/ARCHITECTURE.md` planned)
+
+## Future
+
+Microservice split is deferred to post-beta. The dashboard remains intentionally monolithic for v0.1.0.

--- a/docs/decisions/0005-nginx-reverse-proxy.md
+++ b/docs/decisions/0005-nginx-reverse-proxy.md
@@ -1,0 +1,49 @@
+# ADR-0005: Nginx Reverse Proxy for All User-Facing Services
+
+**Status:** Planned (not yet implemented)
+**Date:** 2026-04-10
+
+## Context
+
+15 services expose raw ports directly to the host. There is no SSL, no centralized CSP header management, and no unified routing. An nginx configuration exists in `config/nginx/nginx.conf` but is not wired into `docker-compose.yml`.
+
+## Decision
+
+Add nginx as a container in `docker-compose.yml` and make it the single entry point for all user-facing services.
+
+## Rationale
+
+1. Centralizes SSL termination (future Let's Encrypt support)
+2. Single CSP header management point — currently each service configures its own headers
+3. Clean URLs (e.g., `homeforge.local/media` instead of `:8096`)
+4. WebSocket upgrade support for dashboard terminal and Matrix
+5. Industry standard for reverse proxying — well-documented, well-understood
+
+## Current State
+
+`config/nginx/nginx.conf` exists with proxy blocks for 5 of 15 services (Dashboard, Jellyfin, Nextcloud, Element, Vaultwarden). The nginx container is NOT in `docker-compose.yml`.
+
+## Planned Implementation
+
+- Add nginx service to `docker-compose.yml`
+- Complete proxy config for all 15 user-facing services
+- WebSocket upgrade support (`Upgrade: websocket` → `Connection: upgrade`)
+- Healthcheck for nginx container
+- Documented SSL placeholder strategy (self-signed for LAN, Let's Encrypt for domain)
+
+## Consequences
+
+**Positive:**
+- Single entry point for all user-facing traffic
+- Centralized SSL termination
+- CSP headers managed in one place
+- Cleaner URLs for users
+
+**Negative:**
+- Nginx becomes a critical dependency — if it fails, all services are unreachable
+- Configuration complexity for 15 services
+- Must update `boom.sh` and `install.sh` to reference nginx as the primary entry point
+
+## Migration Path
+
+Existing users access services via direct ports. After nginx is added, both direct ports and nginx proxy will work during transition. Direct ports can be removed once users migrate.

--- a/docs/decisions/0006-flat-data-volumes.md
+++ b/docs/decisions/0006-flat-data-volumes.md
@@ -1,0 +1,62 @@
+# ADR-0006: Flat Data Volume Structure Under ./data/
+
+**Status:** Accepted (documenting current reality)
+**Date:** 2026-04-10
+
+## Context
+
+Each HomeForge service needs persistent storage. We chose a flat `./data/<service-name>/` structure on the host filesystem.
+
+## Decision
+
+All service data lives under a single `./data/` directory on the host, with one subdirectory per service.
+
+## Rationale
+
+1. **Simple to understand** — one directory, all your data
+2. **Simple to back up** — archive `./data/` and you have everything
+3. **Simple to migrate** — copy the directory, everything works
+4. **No complex volume management** — bind mounts instead of Docker named volumes
+5. **Dashboard metrics** — mounts `./data` read-only to collect metrics across all services
+
+## Data Hierarchy
+
+```
+data/
+├── jellyfin/config/       # Jellyfin configuration
+├── jellyfin/cache/        # Transcoded media cache
+├── nextcloud/html/        # Nextcloud web root
+├── nextcloud/data/        # User files (Nextcloud data dir)
+├── nextcloud/db/          # MariaDB database files
+├── matrix/db/             # Postgres data (Synapse DB volume)
+├── matrix/synapse/        # Synapse homeserver data
+├── vaultwarden/           # Password vault data
+├── open-webui/            # Open-WebUI backend data
+├── ollama/                # LLM models
+├── kiwix/                 # ZIM files + library.xml
+├── vpn/                   # OpenVPN config, certs, PKI
+├── workspace/             # Shared workspace (Theia IDE)
+├── filebrowser/           # Kiwix manager database
+├── security/              # Dashboard entropy-encrypted user DB
+└── backups/               # User-initiated backups
+```
+
+## Consequences
+
+**Positive:**
+- All data in one place — easy backup, easy understanding
+- Dashboard can mount `./data` read-only for cross-service metrics
+- Backup system depends on this simple structure
+- Users can browse their data without Docker commands
+
+**Negative:**
+- No separation between config, state, and user data within each service directory
+- Flat structure does not scale well if services add nested directories
+- Backup system must be aware of which directories to include/exclude
+
+## Future
+
+Consider a documented contract that separates:
+- `data/*/config/` — service configuration (backup: yes)
+- `data/*/state/` — service state, caches (backup: no)
+- `data/*/user-data/` — user files (backup: yes)


### PR DESCRIPTION
Part of #176 (Phase 2)

## What this does

Adds three Docker networks and assigns every service to the right one:

| Network | Services |
|---|---|
| **frontend** | dashboard, element, openvpn-ui, kiwix-manager, open-webui |
| **backend** | jellyfin, nextcloud, collabora, theia, synapse, vaultwarden, kiwix, ollama, openvpn |
| **database** | db (MariaDB), synapse-db (Postgres) |

**Cross-network assignments:**
- dashboard → frontend + backend (needs to reach all services for health checks)
- open-webui → frontend + backend (needs ollama on backend)
- nextcloud → backend + database (needs MariaDB)
- synapse → backend + database (needs Postgres)

**What changed:**
- Ollama port  removed from host — only open-webui reaches it internally
- Databases are on  network only — unreachable from frontend services

**Validated:**  passes

**What changes for users:** Nothing visible. All existing ports work the same.