### PR TITLE
docs: Phase 4 — Dashboard internal architecture

### DIFF
--- a/Dashboard/Dashboard1/docs/ARCHITECTURE.md
+++ b/Dashboard/Dashboard1/docs/ARCHITECTURE.md
@@ -1,0 +1,285 @@
+# Dashboard Internal Architecture
+
+## Overview
+
+The HomeForge Dashboard is a Next.js 16 application that serves as the central control plane for the entire HomeForge ecosystem. It is intentionally monolithic — all logic (auth, session management, API routes, WebSocket terminal, backup/restore, metrics) lives in one codebase.
+
+**Tech stack:** Next.js 16, React 19, TypeScript, Tailwind CSS v4, Radix UI
+**Runtime:** Node.js 20-slim (Docker)
+**Database:** SQLCipher (AES-256-GCM encrypted SQLite) via `better-sqlite3-multiple-ciphers`
+**Password hashing:** Argon2id (64 MiB memory, 3 iterations)
+**Session management:** iron-session v8 (HTTP-only, signed, encrypted cookies)
+
+## Directory Structure
+
+```
+Dashboard/Dashboard1/
+├── app/
+│   ├── api/
+│   │   ├── auth/          # Session, login, ws-ticket, setup, admin user management
+│   │   ├── backup/        # Backup/restore orchestration
+│   │   ├── kiwix/         # Kiwix ZIM file browsing proxy
+│   │   ├── ollama/        # Ollama model management proxy
+│   │   └── stats/         # Docker container health and resource stats
+│   ├── kiwix/             # Kiwix reader page
+│   ├── login/             # Login page
+│   ├── setup/             # One-time entropy key + admin setup
+│   ├── globals.css
+│   ├── layout.tsx         # Root layout with theme provider
+│   └── page.tsx           # Dashboard home (module cards, metrics)
+├── components/
+│   ├── dashboard/         # UI components (welcome section, terminal panel, etc.)
+│   ├── metrics/           # Metrics UI (resource graphs, service health)
+│   └── ui/                # shadcn/ui primitives
+├── hooks/                 # React hooks
+├── lib/
+│   ├── auth.ts            # Session guards (requireSession, requireAdmin)
+│   ├── session.ts         # iron-session configuration
+│   ├── rate-limit.ts      # Sliding-window rate limiter
+│   ├── landing-data.ts    # Static landing page data
+│   ├── utils.ts           # Shared utilities
+│   ├── crypto/
+│   │   ├── entropy.ts     # Mouse entropy collection + key derivation
+│   │   └── keystore.ts    # SQLCipher database management
+│   └── db/                # Database query layer
+├── types/                 # TypeScript type definitions
+├── middleware.ts           # Session guard (runs before every request)
+├── custom-server.ts       # WebSocket terminal server (port 3070)
+└── start.sh               # Entrypoint: runs bootstrap.js, then starts Next.js + WS server
+```
+
+## Layer Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Browser                                                             │
+│  ┌─────────┐  ┌──────────┐  ┌──────────────┐  ┌──────────────────┐  │
+│  │ /login   │  │ /setup   │  │ /api/*       │  │ xterm.js terminal│  │
+│  │ (form)   │  │ (canvas) │  │ (fetch)      │  │ (WebSocket :3070)│  │
+│  └────┬─────┘  └────┬─────┘  └──────┬───────┘  └────────┬─────────┘  │
+│       │              │              │                    │             │
+└───────┼──────────────┼──────────────┼────────────────────┼─────────────┘
+        │              │              │                    │
+        ▼              ▼              ▼                    ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  Next.js Middleware (middleware.ts)                                   │
+│  ┌─────────────────────────────────────────────────────────────────┐ │
+│  │ 1. Check if path is public (/login, /setup, /api/auth, /_next)  │ │
+│  │ 2. If not public → validate iron-session cookie                  │ │
+│  │ 3. If no session → redirect to /login                            │ │
+│  │ 4. If valid → inject x-user-id, x-user-role, x-username headers │ │
+│  └─────────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  API Routes (app/api/*)                                               │
+│  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐ ┌─────────────┐ │
+│  │ /api/auth/   │ │ /api/backup/ │ │ /api/kiwix/  │ │ /api/stats/ │ │
+│  │ login,       │ │ create,      │ │ browse,      │ │ containers, │ │
+│  │ session,     │ │ restore,     │ │ upload       │ │ health       │ │
+│  │ ws-ticket,   │ │ status       │ │              │ │              │ │
+│  │ setup, users │ │              │ │              │ │              │ │
+│  └──────┬───────┘ └──────┬───────┘ └──────┬───────┘ └──────┬──────┘ │
+│         │                │                │                  │         │
+└─────────┼────────────────┼────────────────┼──────────────────┼─────────┘
+          │                │                │                  │
+          ▼                ▼                ▼                  ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  Server Components (page.tsx, layouts)                                │
+│  ┌─────────────────────────────────────────────────────────────────┐ │
+│  │ requireSession() → reads iron-session cookie, redirects if none │ │
+│  │ requireAdmin()   → checks session.role === 'admin', redirects   │ │
+│  │ Fetches Docker stats, service health, metrics                   │ │
+│  └─────────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────────┘
+          │
+          ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  Business Logic (lib/)                                                │
+│  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐ ┌─────────────┐ │
+│  │ auth.ts      │ │ session.ts   │ │ rate-limit.ts│ │ keystore.ts │ │
+│  │ getSession() │ │ SessionData  │ │ SlidingWindow│ │ SQLCipher   │ │
+│  │ requireAdmin()│ │ options      │ │ RateLimiter  │ │ management  │ │
+│  └──────────────┘ └──────────────┘ └──────────────┘ └──────┬──────┘ │
+│                                                             │         │
+│  ┌──────────────────────────────┐  ┌──────────────────────┐ │         │
+│  │ entropy.ts                   │  │ Docker socket API    │ │         │
+│  │ HKDF key derivation          │  │ /var/run/docker.sock │ │         │
+│  │ Mouse movement + CSPRNG      │  │ containers, stats    │ │         │
+│  └──────────────────────────────┘  └──────────────────────┘ │         │
+└─────────────────────────────────────────────────────────────────────┘
+          │                                          │
+          ▼                                          ▼
+┌────────────────────────────────┐  ┌───────────────────────────────────┐
+│  SQLCipher Database            │  │  WebSocket Terminal (:3070)       │
+│  ./data/security/homeforge.db  │  │  custom-server.ts                  │
+│  ┌──────────────────────────┐  │  │  ┌─────────────────────────────┐  │
+│  │ users (id, username,     │  │  │  │ verifyWsTicket()            │  │
+│  │ password_hash, role,     │  │  │  │ pty.spawn(bash/docker exec) │  │
+│  │ created_at)              │  │  │  │ 30-min idle timeout          │  │
+│  │ Encrypted: AES-256-GCM   │  │  │  │ ALLOWED_CONTAINERS whitelist │  │
+│  └──────────────────────────┘  │  │  │ Ollama shell, container shell│  │
+│                                │  │  │ unified bash shell           │  │
+│  ┌──────────────────────────┐  │  │  └─────────────────────────────┘  │
+│  │ setup state              │  │  │                                   │
+│  │ (temporary UUID key      │  │  │  Connection flow:                 │  │
+│  │  → PRAGMA rekey          │  │  │  1. Client fetches /api/auth/    │  │
+│  │  → entropy-derived key)  │  │  │     ws-ticket (short-lived HMAC) │  │
+│  └──────────────────────────┘  │  │  2. Client opens ws://:3070     │  │
+│                                │  │     ?ticket={ticket}             │  │
+│                                │  │  3. Server verifies ticket (30s) │  │
+│                                │  │  4. Spawns PTY session           │  │
+│                                │  │  5. Bidirectional data stream    │  │
+│                                │  └───────────────────────────────────┘  │
+└────────────────────────────────┘
+```
+
+## Authentication Chain
+
+### Entropy Key Derivation
+
+```
+User mouse movement (frontend canvas events)
+  +
+CSPRNG (window.crypto.getRandomValues)
+  │
+  ▼
+SHA-512 hash → 128-char hex entropy key
+  │
+  ▼
+HKDF-SHA512 (three derivations, unique info strings)
+  ├──→ SESSION_SECRET  (iron-session cookie encryption)
+  ├──→ WS_SECRET        (WebSocket ticket HMAC-SHA256)
+  └──→ DB_KEY           (SQLCipher AES-256-GCM encryption)
+```
+
+**Key properties:**
+- All three secrets are derived at runtime, never stored on disk or in `.env`
+- Each HomeForge installation produces cryptographically unique secrets
+- Compromise of one secret does not reveal the others (HKDF independence)
+
+### Database Rekey Flow
+
+1. On first launch, database opens with a temporary UUID-derived key
+2. User completes `/setup` wizard (mouse entropy collection)
+3. `PRAGMA rekey` transitions database from temporary key to entropy-derived `DB_KEY`
+4. Subsequent opens use the entropy-derived key
+
+### Session Flow
+
+1. User submits username + password to `/api/auth/login`
+2. Argon2id hash compared against SQLCipher database
+3. On success: `getIronSession()` creates encrypted cookie (`homeforge_session`)
+4. Cookie is HTTP-only, signed, AES-256-GCM encrypted (iron-session v8)
+5. TTL: 7 days
+6. `middleware.ts` validates cookie on every request
+
+### WebSocket Terminal Auth Flow
+
+1. Client calls `GET /api/auth/ws-ticket` → server returns HMAC-SHA256 ticket
+2. Ticket format: `{timestamp_ms}.{hmac}` — valid for 30 seconds
+3. Client opens `ws://localhost:3070/?ticket={ticket}&shell={type}`
+4. `custom-server.ts` verifies ticket with constant-time HMAC comparison
+5. On success: spawns PTY session (bash, docker exec, or ollama shell)
+6. 30-minute idle timeout closes session
+
+## API Route Map
+
+### /api/auth/*
+| Route | Method | Auth Required | Admin Required | Purpose |
+|---|---|---|---|---|
+| `/api/auth/login` | POST | No | No | Authenticate user, set session |
+| `/api/auth/session` | GET/DELETE | GET: No, DELETE: Yes | No | Get current session or destroy it |
+| `/api/auth/ws-ticket` | GET | Yes | No | Issue short-lived WebSocket ticket |
+| `/api/auth/setup` | POST | No | No | One-time entropy key + admin creation |
+| `/api/auth/setup/status` | GET | No | No | Check if setup is complete |
+| `/api/auth/users` | GET/POST | Yes | Yes | List users or create new user |
+| `/api/auth/users/[id]` | PATCH/DELETE | Yes | Yes | Update or delete user |
+
+### /api/backup/*
+| Route | Method | Auth Required | Admin Required | Purpose |
+|---|---|---|---|---|
+| `/api/backup/create` | POST | Yes | Yes | Create backup archive |
+| `/api/backup/restore` | POST | Yes | Yes | Restore from backup |
+| `/api/backup/list` | GET | Yes | No | List available backups |
+| `/api/backup/status` | GET | Yes | No | Get backup operation status |
+
+### /api/kiwix/*
+| Route | Method | Auth Required | Admin Required | Purpose |
+|---|---|---|---|---|
+| `/api/kiwix/library` | GET | Yes | No | List ZIM files in Kiwix library |
+| `/api/kiwix/upload` | POST | Yes | Yes | Upload ZIM file |
+| `/api/kiwix/delete` | POST | Yes | Yes | Delete ZIM file |
+
+### /api/ollama/*
+| Route | Method | Auth Required | Admin Required | Purpose |
+|---|---|---|---|---|
+| `/api/ollama/models` | GET | Yes | No | List loaded Ollama models |
+| `/api/ollama/pull` | POST | Yes | Yes | Pull new model |
+| `/api/ollama/delete` | POST | Yes | Yes | Delete model |
+
+### /api/stats/*
+| Route | Method | Auth Required | Admin Required | Purpose |
+|---|---|---|---|---|
+| `/api/stats/containers` | GET | Yes | No | List all containers with status |
+| `/api/stats/health` | GET | Yes | No | Get service health from Docker |
+| `/api/stats/resources` | GET | Yes | No | Get host CPU, RAM, disk usage |
+
+## Security Boundaries
+
+### Password Hashing
+- **Algorithm:** Argon2id
+- **Memory:** 64 MiB
+- **Iterations:** 3
+- **Parallelism:** 1
+- Credentials are never stored in plaintext — only the Argon2id hash is persisted
+
+### Rate Limiting
+- **Endpoint:** `/api/auth/login`
+- **Window:** 15 minutes (sliding)
+- **Max attempts:** 10 per username
+- **Headers:** Returns `X-RateLimit-*` headers
+- **Storage:** In-memory Map (per-process)
+
+### Container Access (WebSocket Terminal)
+- **Allowlist:** 16 container names hardcoded in `custom-server.ts`
+- **Shell types:** `ollama` (direct ollama shell), `container` (docker exec into named container), `null` (unified bash shell in dashboard container)
+- **Idle timeout:** 30 minutes with no input
+- **Ticket expiry:** 30 seconds from issuance
+
+## Startup Sequence (start.sh)
+
+```
+1. Run bootstrap.js
+   ├── Check if .env exists
+   ├── If first run: generate entropy key from environment
+   ├── Derive SESSION_SECRET, WS_SECRET, DB_KEY via HKDF
+   ├── Export as environment variables for the process
+   └── Check if setup is complete
+
+2. Start Next.js standalone server (server.js) on $PORT (3069)
+   └── Next.js handles HTTP requests, API routes, Server Components
+
+3. Start WebSocket terminal server (custom-server.js) on $WS_PORT (3070)
+   └── Handles PTY sessions, Docker exec, Ollama shell
+
+4. Both servers run as child processes of start.sh
+   └── start.sh traps SIGTERM and propagates to both children
+```
+
+## Docker Socket Access
+
+The dashboard mounts `/var/run/docker.sock` from the host to:
+- List and inspect containers (health checks, stats)
+- Execute `docker exec` commands for the terminal
+- Run `docker compose` commands for backup/restore
+
+**Security note:** Full Docker socket access = root on host. The dashboard runs as `root` inside the container (required for node-pty native bindings). This is a known trade-off for simplicity — future hardening could use a Docker socket proxy with restricted API access.
+
+## What's Not Documented Here
+
+- UI component internals — see individual component files
+- Theming system — `theme-provider.tsx`, Tailwind config
+- Build process — Dockerfile, next.config.mjs
+- Test suite — `__tests__/`, vitest.config.ts

--- a/Dashboard/Dashboard1/lib/auth.ts
+++ b/Dashboard/Dashboard1/lib/auth.ts
@@ -1,3 +1,19 @@
+/**
+ * Session Guards — Server Component / Route Handler helpers
+ *
+ * These functions are the second layer of auth after middleware.ts.
+ * Middleware validates the cookie on every request, but Server Components
+ * and Route Handlers need programmatic access to the session data.
+ *
+ * Flow:
+ * getSession()     → read and decrypt iron-session cookie, return user data or null
+ * requireSession() → getSession() + redirect to /login if no session
+ * requireAdmin()   → requireSession() + redirect to / if role !== 'admin'
+ *
+ * @see {@link middleware.ts} for the edge runtime session guard
+ * @see {@link lib/session.ts} for session configuration
+ * @see {@link Dashboard/Dashboard1/docs/ARCHITECTURE.md} for full auth chain
+ */
 import { getIronSession } from 'iron-session'
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'

--- a/Dashboard/Dashboard1/lib/session.ts
+++ b/Dashboard/Dashboard1/lib/session.ts
@@ -1,3 +1,21 @@
+/**
+ * iron-session v8 Configuration
+ *
+ * The session cookie is the primary auth mechanism for the entire dashboard.
+ *
+ * Cookie: homeforge_session
+ * Encryption: AES-256-GCM (iron-session v8)
+ * Password: SESSION_SECRET — derived from entropy key via HKDF-SHA512
+ * TTL: 7 days (604800 seconds)
+ * Transport: HTTP-only, signed, encrypted
+ * Secure: true in production (HTTPS required), false in dev
+ *
+ * The password getter throws if SESSION_SECRET is not set, ensuring the server
+ * cannot start without proper bootstrap (start.sh → bootstrap.js).
+ *
+ * @see {@link lib/auth.ts} for session guards
+ * @see {@link Dashboard/Dashboard1/docs/ARCHITECTURE.md} for entropy key derivation
+ */
 import type { SessionOptions } from 'iron-session'
 
 export interface SessionData {

--- a/Dashboard/Dashboard1/middleware.ts
+++ b/Dashboard/Dashboard1/middleware.ts
@@ -1,3 +1,22 @@
+/**
+ * Next.js Edge Middleware — Session Guard
+ *
+ * Runs before every request (edge runtime, not Node.js).
+ *
+ * Flow:
+ * 1. If path is public (/login, /setup, /api/auth, /_next) → pass through
+ * 2. Otherwise → validate iron-session cookie (homeforge_session)
+ * 3. If no session.userId → redirect to /login
+ * 4. If valid → inject x-user-id, x-user-role, x-username headers
+ *    so Server Components can read identity without re-decrypting the cookie
+ *
+ * Cookie encryption: AES-256-GCM via iron-session v8
+ * Password (SESSION_SECRET): derived from entropy key via HKDF-SHA512
+ * TTL: 7 days
+ *
+ * @see {@link lib/session.ts} for session configuration
+ * @see {@link Dashboard/Dashboard1/docs/ARCHITECTURE.md} for full auth chain
+ */
 import { NextRequest, NextResponse } from 'next/server'
 import { getIronSession } from 'iron-session'
 import type { SessionData } from '@/lib/session'

--- a/Project_S_Logs/29_Architecture_Overhaul.md
+++ b/Project_S_Logs/29_Architecture_Overhaul.md
@@ -3,7 +3,7 @@
 Date: 2026-04-10
 Author: Basil Suhail
 Related Issue: #176
-Branch: `phase-1/architecture-docs`
+Branches: `phase-1/architecture-docs`, `phase-2/network-segmentation`, `phase-3/nginx-reverse-proxy`, `phase-4/dashboard-internal`
 
 ---
 
@@ -19,6 +19,17 @@ HomeForge has 15 services orchestrated by Docker Compose, a Next.js 16 dashboard
 - Data volume structure
 - Deployment lifecycle
 - Architecture Decision Records (ADRs)
+
+## Status
+
+| Phase | Status | PR |
+|---|---|---|
+| Phase 1 — Documentation (Architecture doc + ADRs) | ✅ Complete | #177 |
+| Phase 2 — Network Segmentation | ✅ Complete | #178 |
+| Phase 3 — Reverse Proxy Integration | ✅ Complete | #179 |
+| Phase 4 — Dashboard Internal Architecture | In progress | — |
+| Phase 5 — Data Volume Contract | Not started | — |
+| Phase 6 — Validation | Not started | — |
 
 ---
 
@@ -110,40 +121,22 @@ openvpn-ui → openvpn
 
 ## 3. Network Topology (Current State)
 
-**As of April 10, 2026:** All services share a single default Docker Compose network. There is no segmentation. Every container can reach every other container.
+Three Docker networks defined in `docker-compose.yml`:
 
 ```
-Default Docker Network (flat)
-├── project-s-dashboard     (:3069, :3070)
-├── project-s-jellyfin      (:8096)
-├── project-s-nextcloud     (:8081)
-├── project-s-nextcloud-db  (internal, MariaDB)
-├── project-s-collabora     (:9980)
-├── project-s-theia         (:3030)
-├── project-s-matrix-server  (:8008)
-├── project-s-matrix-db      (internal, Postgres)
-├── project-s-matrix-client  (:8082)
-├── project-s-vaultwarden    (:8083)
-├── project-s-open-webui    (:8085)
-├── project-s-ollama        (:11434)
-├── project-s-kiwix-reader  (:8087)
-├── project-s-kiwix-manager (:8086)
-├── project-s-openvpn       (:1194/udp)
-└── project-s-openvpn-ui    (:8090)
-```
-
-**Problems with current topology:**
-1. Databases (MariaDB, Postgres) are reachable from every service — no isolation
-2. Ollama's port 11434 is exposed to the host — only Open-WebUI needs it
-3. Nginx reverse proxy config exists (`config/nginx/nginx.conf`) but is NOT in the compose stack
-4. No network boundaries between public-facing and internal services
-
-**Target topology (planned for Phase 2):**
-```
-frontend network  — nginx, dashboard, element, openvpn-ui, kiwix-manager, open-webui
-backend network   — jellyfin, nextcloud, collabora, theia, synapse, vaultwarden, kiwix, ollama, openvpn
+frontend network  — dashboard, element, openvpn-ui, kiwix-manager, open-webui, nginx
+backend network   — jellyfin, nextcloud, collabora, theia, synapse, vaultwarden, kiwix, ollama, openvpn, nginx
 database network  — db (MariaDB), synapse-db (Postgres)
+
+Cross-network assignments:
+├── dashboard     → frontend + backend (needs to reach all services for health checks)
+├── open-webui    → frontend + backend (needs ollama on backend)
+├── nextcloud     → backend + database (needs MariaDB)
+├── synapse       → backend + database (needs Postgres)
+└── nginx         → frontend + backend (proxies to frontend services + dashboard)
 ```
+
+**User entry point:** All traffic goes through nginx (`http://<LAN_IP>:<port>`). Direct port access removed from all individual services except OpenVPN UDP 1194 (nginx cannot proxy UDP).
 
 ---
 
@@ -155,19 +148,29 @@ database network  — db (MariaDB), synapse-db (Postgres)
 User browser
     │
     ▼
-http://<LAN_IP>:<service_port>     ← Direct port access (no reverse proxy yet)
+http://<LAN_IP>:<port>  ← All traffic through nginx (single entry point, port 80 primary)
     │
     ▼
-Docker Compose port mapping
+nginx reverse proxy (container: project-s-nginx, frontend + backend networks)
+    │
+    ├── :80    → dashboard:3069
+    ├── :8096  → jellyfin:8096
+    ├── :8081  → nextcloud:80
+    ├── :9980  → collabora:9980
+    ├── :3030  → theia:3000
+    ├── :8008  → synapse:8008
+    ├── :8082  → element:80
+    ├── :8083  → vaultwarden:80
+    ├── :8085  → open-webui:8080
+    ├── :8087  → kiwix:8080
+    ├── :8086  → kiwix-manager:80
+    └── :8090  → openvpn-ui:8080
     │
     ▼
-Target container (e.g., nextcloud:80, jellyfin:8096)
+Target container responds via Docker internal DNS
     │
     ▼
-Service responds
-    │
-    ▼
-CSP headers set by docker-compose or nginx (partial)
+CSP headers set by nginx config
     │
     ▼
 Dashboard may iframe the service (Jellyfin, Nextcloud, Element sections)
@@ -469,23 +472,27 @@ HKDF-SHA512 (with unique info strings)
 
 ### ADR-0005: Nginx Reverse Proxy for All User-Facing Services
 
-**Status:** Planned (not yet implemented)
+**Status:** Accepted — implemented PR #179
 **Date:** 2026-04-10
 
-**Context:** 15 services expose raw ports directly to the host. No SSL, no centralized CSP headers, no unified routing. An nginx config exists in `config/nginx/nginx.conf` but is not in the compose stack.
+**Context:** 15 services exposed raw ports directly to the host. No SSL, no centralized CSP headers, no unified routing. An nginx config existed in `config/nginx/nginx.conf` but was not in the compose stack.
 
-**Decision:** Add nginx as a container in docker-compose.yml and make it the single entry point for all user-facing services.
+**Decision:** Add nginx as a container in docker-compose.yml, make it the single entry point for all user-facing services. Remove direct port mappings from individual services (except OpenVPN UDP 1194).
 
 **Rationale:**
 - Centralizes SSL termination (future Let's Encrypt support)
 - Single CSP header management point
 - Clean URLs (e.g., `homeforge.local/media` instead of `:8096`)
-- WebSocket upgrade support for dashboard terminal and Matrix
+- WebSocket upgrade support for dashboard terminal, Collabora, Theia, Matrix, Vaultwarden, Open-WebUI
 - Industry standard for reverse proxying
 
-**Current state:** `config/nginx/nginx.conf` exists with proxy blocks for 5 of 15 services. Not wired into compose.
-
-**Planned:** Full nginx config covering all user-facing services, WebSocket upgrade support, healthcheck, documented SSL placeholder strategy.
+**Implementation:**
+- `nginx:alpine` container on frontend + backend networks
+- Full proxy config for all 15 user-facing services
+- 12 host port mappings consolidated on nginx: 80, 8081, 8082, 8083, 8085, 8086, 8087, 8090, 8096, 9980, 3030, 8008
+- Healthcheck at `/nginx-health`
+- Direct port mappings removed from all individual services
+- OpenVPN UDP 1194 kept on the service (nginx cannot proxy UDP)
 
 ---
 
@@ -517,35 +524,32 @@ HKDF-SHA512 (with unique info strings)
 
 | Issue | Severity | Notes |
 |---|---|---|
-| Nginx not in compose stack | High | `config/nginx/nginx.conf` exists but unused |
-| Flat network — no segmentation | High | All containers can reach all others |
-| Database ports exposed to host | Medium | MariaDB and Postgres should be internal-only |
-| Ollama port 11434 exposed to host | Low | Only Open-WebUI needs it |
-| No SSL/TLS | Medium | All traffic is HTTP on LAN |
+| No SSL/TLS | Medium | All traffic is HTTP on LAN — nginx ready for SSL (future) |
 | OpenVPN restart set to "no" | Low | Known issue on Docker Desktop for Mac (Log 25) |
 | Dashboard runs as root | Medium | Required for Docker socket access |
 | Theia IDE privileged mode | Low | Required for Docker-in-Docker development |
+
+**Resolved:**
+| Issue | Resolution |
+|---|---|
+| Nginx not in compose stack | Fixed — PR #179 |
+| Flat network — no segmentation | Fixed — PR #178 |
+| Database ports exposed to host | Fixed — isolated on database network (PR #178) |
+| Ollama port 11434 exposed to host | Fixed — removed from host (PR #178) |
+| Redundant direct ports | Fixed — all consolidated through nginx (PR #179) |
 
 ---
 
 ## 10. What Needs to Change (Future Phases)
 
-### Phase 2 — Network Segmentation
-- Three networks: `frontend`, `backend`, `database`
-- Remove host ports from internal-only services
-- Database isolation
+### Phase 1 — Documentation ✅ COMPLETE
+### Phase 2 — Network Segmentation ✅ COMPLETE
+### Phase 3 — Reverse Proxy Integration ✅ COMPLETE
 
-### Phase 3 — Reverse Proxy Integration
-- Add nginx to compose
-- Complete proxy config for all 15 services
-- WebSocket upgrade support
-- SSL certificate strategy
-
-### Phase 4 — Dashboard Internal Architecture
-- `Dashboard/Dashboard1/docs/ARCHITECTURE.md`
-- Layer diagram: middleware → auth → session → DB → API → WebSocket
-- API route map with auth requirements
-- WebSocket ticket flow
+### Phase 4 — Dashboard Internal Architecture (In progress)
+- `Dashboard/Dashboard1/docs/ARCHITECTURE.md` — layer diagram, auth chain, API route map, WebSocket flow, backup flow
+- Entropy key derivation chain documented visually
+- Inline architecture comments in key files
 
 ### Phase 5 — Data Volume Contract
 - Documented backup inclusion/exclusion list
@@ -560,4 +564,4 @@ HKDF-SHA512 (with unique info strings)
 ---
 
 **Status:** Living document. Updated as architecture evolves.
-**Next Update:** After Phase 2 (network segmentation) implementation.
+**Next Update:** After Phase 4 (dashboard internal architecture) implementation.


### PR DESCRIPTION
Part of #176 (Phase 4)

## What this does

Documents the black box. The dashboard was an undifferentiated monolith with no internal architecture documented.

**Dashboard/Dashboard1/docs/ARCHITECTURE.md:**
- Layer diagram: middleware → auth → session → SQLCipher DB → API routes → WebSocket server
- Full API route map with auth/admin requirements per route (5 route groups, 20+ endpoints)
- Authentication chain: mouse entropy → HKDF → SESSION_SECRET/WS_SECRET/DB_KEY
- WebSocket terminal ticket flow: HMAC-SHA256, 30s expiry, constant-time comparison
- Startup sequence: start.sh → bootstrap.js → Next.js (3069) + WS server (3070)
- Security boundaries: Argon2id (64 MiB, 3 iterations), sliding-window rate limiter, container allowlist
- Docker socket access explained

**Inline architecture comments added to:**
- `middleware.ts` — session guard flow
- `lib/auth.ts` — requireSession/requireAdmin guards
- `lib/session.ts` — iron-session configuration

**Log 29 updated:**
- Network topology: reflects Phase 2–3 reality (segmented + nginx)
- Data flow: nginx as single entry point
- ADR-0005: Planned → Accepted with implementation details
- Known issues: 5 moved to resolved table
- Future phases: Phase 4 marked in progress