### PR TITLE
feat: Phase 7 — Security hardening (log rotation, healthchecks, network isolation)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,11 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    logging: &default-logging
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   dashboard:
     build:
@@ -52,6 +57,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    logging: *default-logging
 
   db:
     image: mariadb:10.11
@@ -71,6 +77,13 @@ services:
       resources:
         limits:
           memory: 512m
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    logging: *default-logging
 
   nextcloud:
     image: nextcloud:30
@@ -114,6 +127,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+    logging: *default-logging
 
   collabora:
     image: collabora/code:24.04.10.2.1
@@ -149,6 +163,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    logging: *default-logging
 
   theia:
     image: ghcr.io/eclipse-theia/theia-ide/theia-ide:latest  # Theia only publishes :latest on GHCR
@@ -177,6 +192,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    logging: *default-logging
 
   synapse-db:
     image: postgres:15-alpine  # data volume was initialized with PG15 — do NOT bump without pg_upgrade
@@ -191,6 +207,13 @@ services:
     volumes:
       - ./data/matrix/db:/var/lib/postgresql/data
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${MATRIX_DB_USER} -d ${MATRIX_DB_NAME}"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    logging: *default-logging
 
   synapse:
     image: matrixdotorg/synapse:v1.120.0
@@ -221,6 +244,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    logging: *default-logging
 
   element:
     image: vectorim/element-web:v1.11.90
@@ -230,6 +254,13 @@ services:
     volumes:
       - ./config/matrix/element-config.json:/app/config.json:ro
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:80/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    logging: *default-logging
 
   vaultwarden:
     image: vaultwarden/server:1.32.7
@@ -281,6 +312,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+    logging: *default-logging
 
   ollama:
     image: ollama/ollama:0.20.0
@@ -305,6 +337,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    logging: *default-logging
 
   kiwix:
     image: ghcr.io/kiwix/kiwix-serve:3.7.0
@@ -323,6 +356,13 @@ services:
         echo 'No ZIM files found. Add .zim files to ./data/kiwix and click Refresh.' && sleep infinity;
       fi"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    logging: *default-logging
 
   kiwix-manager:
     image: filebrowser/filebrowser:v2.31.2
@@ -335,6 +375,13 @@ services:
       - ./data/filebrowser/database.db:/database.db
     command: ["--database", "/database.db", "--noauth", "--root", "/srv"]
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:80/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    logging: *default-logging
 
   openvpn:
     image: d3vilh/openvpn-server:latest
@@ -349,6 +396,13 @@ services:
     volumes:
       - ./data/vpn:/etc/openvpn
     restart: "no"
+    healthcheck:
+      test: ["CMD", "pgrep", "openvpn"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    logging: *default-logging
 
   openvpn-ui:
     image: d3vilh/openvpn-ui:latest
@@ -367,6 +421,13 @@ services:
       - ./data/vpn/pki:/usr/share/easy-rsa/pki
       - /var/run/docker.sock:/var/run/docker.sock:ro
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    logging: *default-logging
 
   nginx:
     image: nginx:alpine
@@ -398,6 +459,7 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
+    logging: *default-logging
 
 networks:
   frontend:
@@ -406,3 +468,4 @@ networks:
     driver: bridge
   database:
     driver: bridge
+    internal: true

--- a/docs/data-volumes.md
+++ b/docs/data-volumes.md
@@ -1,0 +1,221 @@
+# HomeForge Data Volume Structure
+
+This document is the authoritative reference for all persistent data under `./data/`. Every directory is documented with its purpose, owner, mount type, and backup inclusion status.
+
+## Hierarchy
+
+```
+data/
+├── jellyfin/
+│   ├── config/          # Jellyfin server configuration
+│   └── cache/           # Transcoded media cache (disposable)
+├── media/               # User media files (movies, music, photos)
+├── nextcloud/
+│   ├── html/            # Nextcloud web root (auto-populated on first start)
+│   ├── data/            # User files synced via Nextcloud
+│   └── db/              # MariaDB database (Nextcloud state)
+├── matrix/
+│   ├── db/              # Postgres database (Synapse state)
+│   └── synapse/         # Synapse homeserver data (signing keys, media store)
+├── vaultwarden/         # Password vault (SQLite DB, attachments, icons)
+├── open-webui/          # AI chat backend (user accounts, chat history, settings)
+├── ollama/              # Downloaded LLM models
+├── kiwix/               # ZIM files (offline knowledge bases)
+├── vpn/                 # OpenVPN configuration, certificates, PKI
+│   ├── db/              # OpenVPN UI database
+│   └── pki/             # Easy-RSA public key infrastructure
+├── workspace/           # Shared workspace (Theia IDE projects)
+├── filebrowser/         # Kiwix ZIM file manager database
+├── security/            # Dashboard entropy-encrypted user database (homeforge.db)
+└── backups/             # User-initiated backup archives (.tar.gz)
+```
+
+## Service Data Reference
+
+### Jellyfin (`data/jellyfin/`)
+
+| Directory | Purpose | Owned By | Mounted By | Size Expectation | Backup? |
+|---|---|---|---|---|---|
+| `config/` | Server config, user accounts, library metadata | Jellyfin | jellyfin (rw) | 10–100 MB | Yes |
+| `cache/` | Transcoded media thumbnails, temp files | Jellyfin | jellyfin (rw) | 100 MB – 10 GB | No (disposable) |
+
+**Note:** `cache/` is fully regenerable. Safe to delete to reclaim space.
+
+### Media (`data/media/`)
+
+| Directory | Purpose | Owned By | Mounted By | Size Expectation | Backup? |
+|---|---|---|---|---|---|
+| `media/` | User media library (movies, music, photos) | User | jellyfin (ro) | User-defined | No (user-managed) |
+
+**Note:** This directory is owned and managed by the user. Too large for automated backup. Mount as read-only for Jellyfin.
+
+### Nextcloud (`data/nextcloud/`)
+
+| Directory | Purpose | Owned By | Mounted By | Size Expectation | Backup? |
+|---|---|---|---|---|---|
+| `html/` | Nextcloud web root (PHP app files) | Nextcloud | nextcloud (rw) | 200–400 MB | Yes |
+| `data/` | User files (documents, photos, synced via Nextcloud) | User | nextcloud (rw) | User-defined | No (user-managed) |
+| `db/` | MariaDB database files (Nextcloud state, app config) | MariaDB | db (rw) | 100 MB – 5 GB | Yes |
+
+**Note:** `data/` (user files) is excluded from automated backup due to potentially large size. Back up separately if needed.
+
+### Matrix (`data/matrix/`)
+
+| Directory | Purpose | Owned By | Mounted By | Size Expectation | Backup? |
+|---|---|---|---|---|---|
+| `db/` | Postgres database (Synapse state: rooms, users, messages) | Postgres | synapse-db (rw) | 100 MB – 5 GB | Yes |
+| `synapse/` | Homeserver config, signing keys, media uploads, log config | Synapse | synapse (rw) | 10–500 MB | Yes |
+
+**Note:** The signing keys in `synapse/` are critical — losing them makes your Matrix server unreachable by federation peers. Always back up this directory.
+
+### Vaultwarden (`data/vaultwarden/`)
+
+| Directory | Purpose | Owned By | Mounted By | Size Expectation | Backup? |
+|---|---|---|---|---|---|
+| `vaultwarden/` | SQLite DB, user attachments, icons, config | Vaultwarden | vaultwarden (rw) | 1–100 MB | Yes |
+
+**Note:** This is your entire password vault. Losing this means losing all stored credentials. High priority for backup.
+
+### Open-WebUI (`data/open-webui/`)
+
+| Directory | Purpose | Owned By | Mounted By | Size Expectation | Backup? |
+|---|---|---|---|---|---|
+| `open-webui/` | User accounts, chat history, settings, API keys | Open-WebUI | open-webui (rw) | 1–50 MB | Yes |
+
+### Ollama (`data/ollama/`)
+
+| Directory | Purpose | Owned By | Mounted By | Size Expectation | Backup? |
+|---|---|---|---|---|---|
+| `ollama/` | Downloaded LLM models (weights, manifests) | Ollama | ollama (rw) | 1–50 GB | No (re-downloadable) |
+
+**Note:** Models can be re-downloaded. Excluded from backup due to large size. Track which models are installed via Open-WebUI.
+
+### Kiwix (`data/kiwix/`)
+
+| Directory | Purpose | Owned By | Mounted By | Size Expectation | Backup? |
+|---|---|---|---|---|---|
+| `kiwix/` | ZIM files (offline Wikipedia, etc.), library.xml | Kiwix | kiwix (rw) | 1–100 GB | No (user-managed) |
+
+**Note:** ZIM files are large. Managed by user. Excluded from automated backup.
+
+### VPN (`data/vpn/`)
+
+| Directory | Purpose | Owned By | Mounted By | Size Expectation | Backup? |
+|---|---|---|---|---|---|
+| `vpn/` | OpenVPN server config, client profiles | OpenVPN | openvpn (rw) | 1–10 MB | Yes |
+| `vpn/db/` | OpenVPN UI database | OpenVPN UI | openvpn-ui (rw) | < 1 MB | Yes |
+| `vpn/pki/` | Easy-RSA PKI (certificates, keys, CRLs) | OpenVPN | openvpn (rw) | 1–10 MB | Yes |
+
+**Note:** The PKI directory contains all certificates and keys. Losing this means regenerating the entire CA and revoking all client profiles.
+
+### Workspace (`data/workspace/`)
+
+| Directory | Purpose | Owned By | Mounted By | Size Expectation | Backup? |
+|---|---|---|---|---|---|
+| `workspace/` | Shared development workspace (Theia IDE projects) | User | theia (rw) | User-defined | No (user-managed) |
+
+**Note:** This is user development data. Excluded from automated backup.
+
+### Filebrowser (`data/filebrowser/`)
+
+| Directory | Purpose | Owned By | Mounted By | Size Expectation | Backup? |
+|---|---|---|---|---|---|
+| `filebrowser/database.db` | File browser config and state | Kiwix Manager | kiwix-manager (rw) | < 1 MB | Yes |
+
+### Security (`data/security/`)
+
+| Directory | Purpose | Owned By | Mounted By | Size Expectation | Backup? |
+|---|---|---|---|---|---|
+| `security/` | Dashboard user database (SQLCipher encrypted) | Dashboard | dashboard (rw) | < 1 MB | Yes |
+
+**Note:** This is encrypted with the entropy key derived during setup. Without the entropy key, this file is unrecoverable. Highest backup priority.
+
+### Backups (`data/backups/`)
+
+| Directory | Purpose | Owned By | Mounted By | Size Expectation | Backup? |
+|---|---|---|---|---|---|
+| `backups/` | User-initiated backup archives (.tar.gz) | Dashboard | dashboard (rw) | Variable | No (these ARE the backups) |
+
+## Backup System
+
+The automated backup system (`app/api/backup/route.ts`) creates a `.tar.gz` archive of the entire `data/` directory.
+
+### What's Included
+
+Everything under `data/` **except**:
+- `data/backups/` — prevents recursive inclusion of old backups
+- `node_modules/` — dependencies are rebuildable
+- `.git/` — repo history is on GitHub
+- `.next/` — build output is rebuildable
+- `*.log` — transient logs, not user data
+- `tmp/` — temporary files
+
+### What's Excluded (and why)
+
+| Excluded | Reason |
+|---|---|
+| `data/backups/` | Recursive prevention |
+| `data/media/` | User-managed, potentially terabytes |
+| `data/nextcloud/data/` | User files, potentially large |
+| `data/kiwix/` | ZIM files are large, user-managed |
+| `data/ollama/` | Models are re-downloadable |
+| `data/workspace/` | User development data, user-managed |
+
+**Note:** The current tar command uses broad `--exclude` flags. It does NOT exclude user-managed directories like `media/`, `nextcloud/data/`, `kiwix/`, or `ollama/`. This is a known issue — large user data directories get included in backups. The backup archive can become very large.
+
+### Backup Archive Location
+
+`/data/backups/homeforge-backup-<timestamp>.tar.gz`
+
+### Backup History
+
+Tracked in the dashboard's SQLCipher database (`data/security/homeforge.db`) in the `backup_history` table. Records filename, size, status, and creation timestamp.
+
+## Mount Types
+
+### Read-Write (rw) — Service can modify data
+All service data directories are mounted read-write by their respective containers.
+
+### Read-Only (ro) — Service can only read
+| Directory | Mounted By | Reason |
+|---|---|---|
+| `data/` (entire tree) | dashboard | Metrics collection — dashboard monitors all service data without modifying it |
+| `config/nginx/nginx.conf` | nginx | Config should not be modified at runtime |
+| `config/nextcloud/*.sh` | nextcloud | Setup scripts are read-only |
+| `config/collabora/*.xml` | collabora | Config override is read-only |
+| `config/matrix/` | synapse | Config is generated at startup, not modified at runtime |
+| `config/ollama/` | ollama | Modelfiles are read-only |
+| `config/terminal/homelab-shell` | theia | Shell wrapper script is read-only |
+| `/var/run/docker.sock` | dashboard, theia, openvpn-ui | Docker API access (ro for openvpn-ui) |
+
+## Ownership
+
+Each service "owns" its data directory. No service should modify another service's data.
+
+| Service | Owns |
+|---|---|
+| Jellyfin | `data/jellyfin/` |
+| Nextcloud | `data/nextcloud/` |
+| MariaDB | `data/nextcloud/db/` |
+| Synapse | `data/matrix/` |
+| Postgres | `data/matrix/db/` |
+| Vaultwarden | `data/vaultwarden/` |
+| Open-WebUI | `data/open-webui/` |
+| Ollama | `data/ollama/` |
+| Kiwix | `data/kiwix/` |
+| OpenVPN | `data/vpn/` |
+| OpenVPN UI | `data/vpn/db/` |
+| Theia IDE | `data/workspace/` |
+| Kiwix Manager | `data/filebrowser/` |
+| Dashboard | `data/security/`, `data/backups/` |
+
+## Critical Data (Must Never Lose)
+
+| Path | Why It's Critical |
+|---|---|
+| `data/security/homeforge.db` | Encrypted user database — without entropy key, this is unrecoverable |
+| `data/vaultwarden/` | All user passwords and credentials |
+| `data/matrix/synapse/` | Federation signing keys |
+| `data/vpn/pki/` | CA certificates and keys for VPN |
+| `data/nextcloud/db/` | All Nextcloud state (users, files metadata, app config) |
+| `data/matrix/db/` | All Matrix messages, rooms, user accounts |


### PR DESCRIPTION
Part of #182 (audit findings)

## What this does

Addresses the highest-impact, lowest-risk findings from the architecture review.

### Log rotation
- All 15 services now use `json-file` driver with `max-size: 10m`, `max-file: 3`
- Prevents unbounded log growth from filling disk (was: no rotation at all)

### Healthchecks (7 new)
| Service | Healthcheck | Before |
|---|---|---|
| Element | `wget --spider http://localhost:80/` | No healthcheck |
| Kiwix Reader | `wget --spider http://localhost:8080/` | No healthcheck |
| Kiwix Manager | `wget --spider http://localhost:80/` | No healthcheck |
| OpenVPN | `pgrep openvpn` | No healthcheck |
| OpenVPN UI | `wget --spider http://localhost:8080/` | No healthcheck |
| MariaDB | `mysqladmin ping` | No healthcheck |
| Postgres (Synapse) | `pg_isready` | No healthcheck |

### Network isolation
- `database` network now has `internal: true`
- Compromised database containers cannot access the internet (no data exfiltration, no phone home)

### Data volumes documentation
- Moved `data/README.md` to `docs/data-volumes.md`
- Now version-controlled so fresh clones can see the data hierarchy without building first