### PR TITLE
docs: remove Local CA (mkcert) from planned features

### DIFF
--- a/Project_S_Logs/42_Traefik_Migration.md
+++ b/Project_S_Logs/42_Traefik_Migration.md
@@ -126,7 +126,7 @@ Dashboard stays at `:3069` (direct port for initial access).
 | Risk | Mitigation |
 |---|---|
 | Downtime during migration | Rollback script restores nginx in <30s |
-| Self-signed cert warnings | Using `nip.io` — later replace with mkcert local CA |
+| Self-signed cert warnings | Harmless; Tailscale encryptes remote traffic |
 | WebSocket routing | Each WS service has separate router label |
 | Service discovery failure | Traefik watches Docker API — auto-recover on restart |
 | Port 443 conflict | `boom.sh` checks for conflicts before starting |
@@ -135,7 +135,6 @@ Dashboard stays at `:3069` (direct port for initial access).
 
 ## Future Work
 
-1. **Local CA (mkcert)**: Replace self-signed certs with trusted LAN CA
-2. **Let's Encrypt**: For users with public domains
-3. **Middleware chain**: Add rate limiting, auth middleware for sensitive services
-4. **Dashboard integration**: Show Traefik status + routing table in UI
+1. **Let's Encrypt**: For users with public domains
+2. **Middleware chain**: Add rate limiting, auth middleware for sensitive services
+3. **Dashboard integration**: Show Traefik status + routing table in UI

--- a/README.md
+++ b/README.md
@@ -273,7 +273,6 @@ Install once. Get a private, encrypted, modular platform that runs your digital 
 | Workflow automation | n8n |
 | Smart home | Home Assistant |
 | Version control | Gitea |
-| Local CA (mkcert) | Trusted LAN HTTPS |
 
 ---
 

--- a/config/traefik/traefik.yml
+++ b/config/traefik/traefik.yml
@@ -30,8 +30,8 @@ providers:
     directory: /etc/traefik/dynamic
     watch: true
 
-# No certificates yet — use self-signed for local LAN
-# Later: configure ACME with Let's Encrypt or local CA (mkcert)
+# Auto-generated self-signed cert for local LAN access.
+# Tailscale provides encrypted transport for remote access.
 
 log:
   level: INFO


### PR DESCRIPTION
Not needed — self-signed certs + Tailscale encryption covers all access scenarios. Local CA adds maintenance burden (per-device cert install, IP change breakage) with no security benefit.\n\nRemoved from README, Log 42, and traefik config comments.