### PR TITLE
feat: cross-platform host metrics with 3-tier fallback (#174)

### DIFF
--- a/Dashboard/Dashboard1/app/api/stats/route.ts
+++ b/Dashboard/Dashboard1/app/api/stats/route.ts
@@ -9,12 +9,64 @@ import { getDb } from '@/lib/db'
 const execAsync = promisify(exec)
 
 // Helper to fetch metrics from the Host Agent (macOS/Windows support)
+// Tier 1: host.docker.internal:9101 (macOS/Windows agent)
+// Tier 2: /host/proc and /host/sys (Linux mounts)
+// Tier 3: Docker stats only (fallback)
 async function fetchAgentMetrics(): Promise<any | null> {
   try {
-    // Docker Desktop exposes host.docker.internal to the container
+    // Tier 1: Try host agent first (macOS/Windows)
     const res = await fetch('http://host.docker.internal:9101/metrics', { signal: AbortSignal.timeout(2000) })
-    if (res.ok) return await res.json()
+    if (res.ok) {
+      const data = await res.json()
+      return { ...data, source: 'agent' }
+    }
   } catch { /* Agent not running or unreachable */ }
+  
+  // Tier 2: Check if Linux mounts are available
+  if (fs.existsSync('/host/proc/uptime')) {
+    try {
+      const uptimeRaw = fs.readFileSync('/host/proc/uptime', 'utf-8').trim()
+      const uptimeDays = Math.floor(parseFloat(uptimeRaw.split(' ')[0]) / 86400)
+      
+      // Read memory from /host/proc/meminfo
+      let memTotal = 0, memFree = 0
+      const meminfo = fs.readFileSync('/host/proc/meminfo', 'utf-8')
+      for (const line of meminfo.split('\n')) {
+        if (line.startsWith('MemTotal:')) memTotal = parseInt(line.split(/\s+/)[1]) * 1024
+        if (line.startsWith('MemAvailable:')) memFree = parseInt(line.split(/\s+/)[1]) * 1024
+      }
+      
+      // Read load average from /host/proc/loadavg
+      let loadAvg = [0, 0, 0]
+      const loadavg = fs.readFileSync('/host/proc/loadavg', 'utf-8').trim()
+      loadAvg = loadavg.split(' ').slice(0, 3).map(Number)
+      
+      // Read CPU temp from /host/sys/class/thermal if available
+      let cpuTemp = null
+      if (fs.existsSync('/host/sys/class/thermal')) {
+        try {
+          const zones = fs.readdirSync('/host/sys/class/thermal').filter(f => f.startsWith('thermal_zone'))
+          for (const zone of zones) {
+            const temp = parseInt(fs.readFileSync(`/host/sys/class/thermal/${zone}/temp`, 'utf-8').trim()) / 1000
+            if (temp > 0) { cpuTemp = temp; break }
+          }
+        } catch { /* ignore */ }
+      }
+      
+      return {
+        source: 'linux-mounts',
+        platform: 'linux',
+        uptime: uptimeDays,
+        memory: { total: memTotal, free: memFree, used: memTotal - memFree, usedPerc: Math.round(((memTotal - memFree) / memTotal) * 100 * 10) / 10 },
+        cpu: { loadAvg, usage: null, cores: null },
+        temps: { cpu: cpuTemp, sys: null },
+        disk: [],
+        network: { rxBytes: 0, txBytes: 0, rxErrors: 0, txErrors: 0 }
+      }
+    } catch { /* Linux mounts read failed */ }
+  }
+  
+  // Tier 3: No host access — Docker VM only
   return null
 }
 
@@ -479,6 +531,8 @@ export async function GET() {
       backup: backupData,
       ups: upsData,
       platform: agentData?.platform || (fs.existsSync('/host/proc') ? 'linux' : 'docker-vm'),
+      agentConnected: agentData?.source === 'agent',
+      metricsSource: agentData?.source || 'docker-only',
     }
 
     // Write to SQLite history (every poll)

--- a/Dashboard/Dashboard1/components/dashboard/metrics-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/metrics-section.tsx
@@ -40,6 +40,9 @@ interface StatsData {
   power: { watts: number | null; kwhEstimate: number | null }
   backup: { lastRun: number | null; lastRunAgo: string | null; success: boolean | null; size: string | null }
   ups: { batteryPerc: number | null; loadPerc: number | null; runtimeMin: number | null; status: string | null }
+  platform: string
+  agentConnected: boolean
+  metricsSource: string
 }
 
 interface HistoryPoint {
@@ -409,9 +412,26 @@ export function MetricsSection() {
 
       {/* Header bar */}
       <div className="flex items-center justify-between px-3 sm:px-6 py-2.5 shrink-0 border-b border-border">
-        <div>
-          <h2 className="text-sm font-semibold text-foreground">Metrics</h2>
-          <p className="text-[10px] text-foreground/25 mt-0.5">Real-time · 5s refresh</p>
+        <div className="flex items-center gap-3">
+          <div>
+            <h2 className="text-sm font-semibold text-foreground">Metrics</h2>
+            <p className="text-[10px] text-foreground/25 mt-0.5">Real-time · 5s refresh</p>
+          </div>
+          {/* Platform badge */}
+          <span className={`px-2 py-0.5 rounded text-[9px] font-bold uppercase tracking-tight border ${
+            stats.platform === 'linux' ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20' :
+            stats.platform === 'darwin' ? 'bg-blue-500/10 text-blue-400 border-blue-500/20' :
+            stats.platform === 'win32' ? 'bg-indigo-500/10 text-indigo-400 border-indigo-500/20' :
+            'bg-secondary/10 text-foreground/30 border-border'
+          }`}>
+            {stats.platform === 'darwin' ? 'macOS' : stats.platform === 'win32' ? 'Windows' : stats.platform}
+          </span>
+          {/* Agent status */}
+          {stats.agentConnected && (
+            <span className="px-2 py-0.5 rounded text-[9px] font-bold uppercase tracking-tight bg-cyan-500/10 text-cyan-400 border border-cyan-500/20" title="Host agent providing metrics">
+              Agent Connected
+            </span>
+          )}
         </div>
         <div className="relative" ref={rangeRef}>
           <button onClick={() => setRangeOpen(!rangeOpen)} className="flex items-center gap-1.5 px-2.5 py-1 text-[11px] font-medium text-foreground/50 bg-secondary/10 rounded-md border border-border hover:bg-secondary/20 transition-colors">

--- a/scripts/host-agent.js
+++ b/scripts/host-agent.js
@@ -1,109 +1,329 @@
 #!/usr/bin/env node
 /**
- * HomeForge Host Agent
- * Runs on the host machine (macOS/Windows/Linux) to provide real system metrics
- * to the Dashboard container via HTTP.
- *
+ * HomeForge Host Agent — Cross-platform metrics collector
+ * 
+ * Reads host machine metrics (CPU, memory, disk, network, temps)
+ * and exposes them via HTTP for the Dashboard to consume.
+ * 
  * Usage: node scripts/host-agent.js
- * Port: 9101 (default)
+ * Access: http://localhost:9101/metrics
+ * 
+ * No dependencies required — uses only Node.js built-in modules.
  */
 
 const http = require('http');
 const os = require('os');
-const { execSync } = require('child_process');
+const { exec } = require('child_process');
+const { promisify } = require('util');
 
-const PORT = process.env.HOMEFORGE_AGENT_PORT || 9101;
+const execAsync = promisify(exec);
 
-function getDiskUsage() {
+const PORT = 9101;
+const HOST = '0.0.0.0';
+
+// Cache metrics for 2 seconds to avoid excessive polling
+let cachedMetrics = null;
+let cacheTime = 0;
+const CACHE_TTL = 2000;
+
+/**
+ * Get CPU usage percentage
+ */
+function getCPUUsage() {
+  const cpus = os.cpus();
+  let totalIdle = 0;
+  let totalTick = 0;
+
+  for (const cpu of cpus) {
+    const { user, nice, sys, irq, idle } = cpu.times;
+    totalIdle += idle;
+    totalTick += user + nice + sys + irq + idle;
+  }
+
+  const usage = 1 - (totalIdle / totalTick);
+  return Math.round(usage * 100 * 10) / 10;
+}
+
+/**
+ * Get memory info
+ */
+function getMemoryInfo() {
+  const total = os.totalmem();
+  const free = os.freemem();
+  const used = total - free;
+  const usedPerc = Math.round((used / total) * 100 * 10) / 10;
+  
+  return { total, free, used, usedPerc };
+}
+
+/**
+ * Get disk usage — platform specific
+ */
+async function getDiskInfo() {
   try {
-    // macOS: df -h
-    // Windows: wmic (deprecated, but reliable on older; Powershell on newer) -> stick to df -h for now (WSL/Linux/Mac compatible)
-    const output = execSync("df -h | grep -v -E 'tmpfs|devtmpfs|overlay|udev|shm'").toString();
-    const lines = output.trim().split('\n').slice(1);
-    return lines.map(line => {
-      const parts = line.trim().split(/\s+/);
-      if (parts.length >= 6) {
+    if (process.platform === 'win32') {
+      // Windows: Use wmic
+      const { stdout } = await execAsync(
+        'wmic logicaldisk get Size,FreeSpace,DeviceID /format:csv'
+      );
+      const lines = stdout.trim().split('\n').slice(1);
+      return lines.map(line => {
+        const [, device, free, size] = line.split(',');
+        const sizeNum = parseInt(size) || 0;
+        const freeNum = parseInt(free) || 0;
+        const used = sizeNum - freeNum;
+        const usePerc = sizeNum > 0 ? Math.round((used / sizeNum) * 100) : 0;
         return {
-          mount: parts[5],
-          total: parts[1],
-          used: parts[2],
-          avail: parts[3],
-          usePerc: parseInt(parts[4]) || 0
+          mount: device,
+          total: sizeNum,
+          free: freeNum,
+          used,
+          usePerc
         };
-      }
-      return null;
-    }).filter(Boolean);
-  } catch {
+      }).filter(d => d.total > 0);
+    } else {
+      // macOS/Linux: Use df
+      const { stdout } = await execAsync(
+        'df -k / | tail -1'
+      );
+      const parts = stdout.trim().split(/\s+/);
+      const total = parseInt(parts[1]) * 1024;
+      const used = parseInt(parts[2]) * 1024;
+      const free = parseInt(parts[3]) * 1024;
+      const usePerc = parseInt(parts[4]) || 0;
+      
+      return [{ mount: '/', total, used, free, usePerc }];
+    }
+  } catch (err) {
+    console.error('Disk info error:', err.message);
     return [];
   }
 }
 
-function getNetworkStats() {
-  const netInterfaces = os.networkInterfaces();
-  let rxBytes = 0;
-  let txBytes = 0;
-  
-  // Note: Node.js 'os' module doesn't give byte counters directly. 
-  // We would need a native addon or parsing /proc/net/dev. 
-  // For a JS-only agent, we'll return current IPs and skip byte counters for now.
-  // *Refinement*: On macOS we can parse `netstat -ib`.
-  
+/**
+ * Get network stats — platform specific
+ */
+async function getNetworkInfo() {
   try {
-    // macOS / Linux
-    const output = execSync("netstat -ibn").toString();
-    const lines = output.trim().split('\n').slice(1);
-    
-    for (const line of lines) {
-      if (line.includes('lo') || line.includes('Link')) continue;
-      const parts = line.trim().split(/\s+/);
-      // netstat -ib columns vary, but usually bytes are around index 6/9
-      // This is tricky cross-platform. 
-      // Fallback to 0 for safety until we implement proper parsing.
+    const interfaces = os.networkInterfaces();
+    let rxBytes = 0;
+    let txBytes = 0;
+    let rxErrors = 0;
+    let txErrors = 0;
+
+    if (process.platform === 'linux') {
+      // Linux: Read from /proc/net/dev
+      try {
+        const { stdout } = await execAsync(
+          'cat /proc/net/dev | grep -v "lo:" | tail -n +3'
+        );
+        const lines = stdout.trim().split('\n');
+        for (const line of lines) {
+          const parts = line.trim().split(/\s+/);
+          if (parts.length >= 11) {
+            rxBytes += parseInt(parts[1]) || 0;
+            txBytes += parseInt(parts[9]) || 0;
+            rxErrors += parseInt(parts[2]) || 0;
+            txErrors += parseInt(parts[10]) || 0;
+          }
+        }
+      } catch {
+        // Fallback to 0
+      }
+    } else if (process.platform === 'darwin') {
+      // macOS: Use netstat
+      try {
+        const { stdout } = await execAsync(
+          'netstat -ib | grep -v "Name" | grep -v "loopback"'
+        );
+        const lines = stdout.trim().split('\n');
+        for (const line of lines) {
+          const parts = line.split(/\s+/);
+          if (parts.length >= 7) {
+            rxBytes += parseInt(parts[parts.length - 2]) || 0;
+            txBytes += parseInt(parts[parts.length - 1]) || 0;
+          }
+        }
+      } catch {
+        // Fallback to 0
+      }
+    } else {
+      // Windows: Use performance counters
+      try {
+        const { stdout } = await execAsync(
+          'powershell "Get-NetAdapter | Where-Object Status -eq \'Up\' | Measure-Object -Property BytesReceived,BytesSent -Sum"'
+        );
+        // Parse PowerShell output
+        const match = stdout.match(/BytesReceived\s*:\s*(\d+)/);
+        const match2 = stdout.match(/BytesSent\s*:\s*(\d+)/);
+        if (match) rxBytes = parseInt(match[1]) || 0;
+        if (match2) txBytes = parseInt(match2[1]) || 0;
+      } catch {
+        // Fallback to 0
+      }
     }
-  } catch {}
-  
-  return { rxBytes, txBytes };
+
+    return { rxBytes, txBytes, rxErrors, txErrors };
+  } catch (err) {
+    console.error('Network info error:', err.message);
+    return { rxBytes: 0, txBytes: 0, rxErrors: 0, txErrors: 0 };
+  }
 }
 
-const server = http.createServer((req, res) => {
-  if (req.url === '/metrics') {
-    const cpus = os.cpus();
-    const loadAvgs = os.loadavg();
-    
-    // Calculate simple CPU usage (idle time vs total time) is hard without sampling.
-    // We will return Load Averages which are standard and useful.
-    
-    const metrics = {
-      platform: os.platform(),
-      hostname: os.hostname(),
-      uptime: Math.floor(os.uptime() / 86400), // Days
-      loadAvg: loadAvgs,
-      memory: {
-        total: os.totalmem(),
-        free: os.freemem(),
-        usedPerc: ((1 - os.freemem() / os.totalmem()) * 100).toFixed(1)
-      },
-      disk: getDiskUsage(),
-      cpu: {
-        model: cpus[0]?.model || 'Unknown',
-        cores: cpus.length,
-        load: loadAvgs // We use Load Avg as the primary "CPU pressure" metric for this agent
+/**
+ * Get CPU temperature — platform specific
+ */
+async function getTemps() {
+  try {
+    if (process.platform === 'darwin') {
+      // macOS: Use osx-cpu-temp or powermetrics
+      try {
+        const { stdout } = await execAsync(
+          'powermetrics --samplers smc | grep -i "CPU die temperature" | head -1'
+        );
+        const match = stdout.match(/(\d+\.\d+)/);
+        const cpu = match ? parseFloat(match[1]) : null;
+        return { cpu: cpu || null, sys: null };
+      } catch {
+        return { cpu: null, sys: null };
       }
-    };
+    } else if (process.platform === 'linux') {
+      // Linux: Read from hwmon
+      try {
+        const { stdout } = await execAsync(
+          'cat /sys/class/thermal/thermal_zone*/temp 2>/dev/null | head -1'
+        );
+        const cpu = parseInt(stdout) / 1000 || null;
+        return { cpu: cpu > 0 ? cpu : null, sys: null };
+      } catch {
+        return { cpu: null, sys: null };
+      }
+    } else {
+      // Windows: Use OpenHardwareMonitor or wmi
+      try {
+        const { stdout } = await execAsync(
+          'wmic /namespace:\\\\root\\OpenHardwareMonitor path HardwareSensor where SensorType=4 get CurrentValue /value'
+        );
+        const match = stdout.match(/CurrentValue=(\d+)/);
+        const cpu = match ? parseInt(match[1]) : null;
+        return { cpu, sys: null };
+      } catch {
+        return { cpu: null, sys: null };
+      }
+    }
+  } catch (err) {
+    console.error('Temp info error:', err.message);
+    return { cpu: null, sys: null };
+  }
+}
 
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(metrics));
-  } else if (req.url === '/health') {
-    res.writeHead(200);
-    res.end('OK');
+/**
+ * Collect all metrics
+ */
+async function collectMetrics() {
+  const platform = process.platform;
+  const hostname = os.hostname();
+  const uptime = Math.round(os.uptime());
+  const loadAvg = os.loadavg();
+  const cpuCount = os.cpus().length;
+  
+  const [disk, network, temps] = await Promise.all([
+    getDiskInfo(),
+    getNetworkInfo(),
+    getTemps()
+  ]);
+
+  return {
+    platform,
+    hostname,
+    uptime,
+    cpu: {
+      usage: getCPUUsage(),
+      loadAvg,
+      cores: cpuCount
+    },
+    memory: getMemoryInfo(),
+    disk,
+    network,
+    temps,
+    timestamp: Date.now()
+  };
+}
+
+/**
+ * Get metrics with caching
+ */
+async function getMetrics() {
+  const now = Date.now();
+  if (cachedMetrics && now - cacheTime < CACHE_TTL) {
+    return cachedMetrics;
+  }
+  
+  cachedMetrics = await collectMetrics();
+  cacheTime = now;
+  return cachedMetrics;
+}
+
+/**
+ * Health check endpoint
+ */
+function healthCheck(res) {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ status: 'ok', platform: process.platform }));
+}
+
+/**
+ * Metrics endpoint
+ */
+async function metricsHandler(res) {
+  try {
+    const metrics = await getMetrics();
+    res.writeHead(200, { 
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-cache'
+    });
+    res.end(JSON.stringify(metrics, null, 2));
+  } catch (err) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: err.message }));
+  }
+}
+
+/**
+ * HTTP server
+ */
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  
+  // CORS headers for local access
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET');
+  
+  if (url.pathname === '/health') {
+    healthCheck(res);
+  } else if (url.pathname === '/metrics') {
+    await metricsHandler(res);
   } else {
-    res.writeHead(404);
-    res.end();
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Not found' }));
   }
 });
 
-server.listen(PORT, '0.0.0.0', () => {
-  console.log(`🩺 HomeForge Host Agent running on port ${PORT}`);
-  console.log(`   Platform: ${os.platform()}`);
+// Start server
+server.listen(PORT, HOST, () => {
+  console.log(`🔧 HomeForge Host Agent running on http://${HOST}:${PORT}`);
   console.log(`   Metrics: http://localhost:${PORT}/metrics`);
+  console.log(`   Health:  http://localhost:${PORT}/health`);
+  console.log(`   Platform: ${process.platform}`);
+  console.log('');
+  console.log('Press Ctrl+C to stop');
+});
+
+// Graceful shutdown
+process.on('SIGINT', () => {
+  console.log('\n👋 Shutting down...');
+  server.close(() => {
+    console.log('Server closed');
+    process.exit(0);
+  });
 });


### PR DESCRIPTION
Implements cross-platform host metrics for macOS, Windows, and Linux.

**Changes:**
- scripts/host-agent.js — Zero-dependency Node.js agent
- Dashboard API — 3-tier fallback logic
- Metrics UI — Platform badge + Agent Connected indicator

**Usage:**
```bash
# macOS/Windows users run:
node scripts/host-agent.js

# Linux users get metrics automatically via /proc mounts
```

Closes #174