### PR TITLE
feat: migration waiter and health-aware startup (#227)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,9 @@ COLLABORA_PASSWORD=change_me_collabora_password
 HOMEFORGE_LAN_IP=
 
 # --- Matrix / Synapse --------------------------------------------------------
+# Public homeserver name used by Synapse clients/federation.
+# For local-only use, keep localhost. For real deployment, set your real domain.
+MATRIX_SERVER_NAME=localhost
 # IMPORTANT: MATRIX_DB_PASSWORD must match the password in config/matrix/homeserver.yaml
 MATRIX_DB_USER=synapse
 MATRIX_DB_PASSWORD=change_me_synapse_password

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ bash scripts/update.sh
 1. Creates encrypted backup
 2. Validates backup integrity
 3. Applies updates
+4. Waits for healthy database-backed startup before traffic reaches app services
 
 ### Rollback (if update breaks)
 
@@ -274,6 +275,7 @@ node scripts/host-agent.js
 | Multi-user auth with iron-session v8 encrypted cookies | ✅ |
 | All core services integrated and functional | ✅ |
 | Nextcloud Office auto-configured on every container start | ✅ |
+| Nextcloud/Synapse startup waits for healthy databases and migration guards | ✅ |
 | Entropy key + SQLCipher encrypted database at rest | ✅ |
 
 ---

--- a/config/matrix/entrypoint.sh
+++ b/config/matrix/entrypoint.sh
@@ -10,7 +10,10 @@ cp /etc/synapse-config/localhost.log.config /data/localhost.log.config
 
 if command -v update_synapse_database >/dev/null 2>&1; then
     echo "[entrypoint] Applying Synapse database migrations"
-    update_synapse_database --database-config /data/homeserver.yaml --run-background-updates
+    (
+        cd /data
+        update_synapse_database --database-config /data/homeserver.yaml --run-background-updates
+    )
 else
     echo "[entrypoint] update_synapse_database not found; Synapse will migrate on startup"
 fi

--- a/config/matrix/entrypoint.sh
+++ b/config/matrix/entrypoint.sh
@@ -1,25 +1,18 @@
 #!/bin/sh
-set -e
+set -eu
 
-# Substitute environment variables into homeserver.yaml before starting Synapse
-# This is needed because Synapse reads the config file directly and doesn't support
-# environment variable interpolation natively.
-INPUT="/data/homeserver.yaml.tpl"
-OUTPUT="/data/homeserver.yaml"
+WAITER="${HOMEFORGE_WAITER:-/usr/local/bin/wait-for-db.sh}"
 
-if [ -f "$INPUT" ]; then
-    # Use envsubst-style replacement with sed
-    sed \
-        -e "s/\${MATRIX_DB_USER}/${MATRIX_DB_USER}/g" \
-        -e "s/\${MATRIX_DB_PASSWORD}/${MATRIX_DB_PASSWORD}/g" \
-        -e "s/\${MATRIX_REGISTRATION_SECRET}/${MATRIX_REGISTRATION_SECRET}/g" \
-        -e "s/\${MATRIX_MACAROON_SECRET_KEY}/${MATRIX_MACAROON_SECRET_KEY}/g" \
-        -e "s/\${MATRIX_FORM_SECRET}/${MATRIX_FORM_SECRET}/g" \
-        "$INPUT" > "$OUTPUT"
-    echo "[entrypoint] homeserver.yaml generated from template"
+"$WAITER" tcp synapse-db 5432 90 "Synapse Postgres"
+
+python3 /etc/synapse-config/gen_config.py
+cp /etc/synapse-config/localhost.log.config /data/localhost.log.config
+
+if command -v update_synapse_database >/dev/null 2>&1; then
+    echo "[entrypoint] Applying Synapse database migrations"
+    update_synapse_database --database-config /data/homeserver.yaml --run-background-updates
 else
-    echo "[entrypoint] Using existing homeserver.yaml (no template found)"
+    echo "[entrypoint] update_synapse_database not found; Synapse will migrate on startup"
 fi
 
-# Start Synapse
 exec python -m synapse.app.homeserver -c /data/homeserver.yaml -c /data/localhost.log.config

--- a/config/matrix/gen_config.py
+++ b/config/matrix/gen_config.py
@@ -10,7 +10,7 @@ def get_secret(key):
 with open('/etc/synapse-config/homeserver.yaml.tpl') as f:
     content = f.read()
 
-for key in ['MATRIX_DB_USER', 'MATRIX_DB_PASSWORD', 'MATRIX_REGISTRATION_SECRET',
+for key in ['MATRIX_SERVER_NAME', 'MATRIX_DB_USER', 'MATRIX_DB_PASSWORD', 'MATRIX_REGISTRATION_SECRET',
             'MATRIX_MACAROON_SECRET_KEY', 'MATRIX_FORM_SECRET']:
     content = content.replace(f'${{{key}}}', get_secret(key))
 

--- a/config/matrix/homeserver.yaml.tpl
+++ b/config/matrix/homeserver.yaml.tpl
@@ -1,4 +1,4 @@
-server_name: "${HOMESERVER_SERVER_NAME}"
+server_name: "${MATRIX_SERVER_NAME}"
 pid_file: /data/homeserver.pid
 listeners:
   - port: 8008
@@ -12,14 +12,14 @@ database:
   name: psycopg2
   args:
     user: synapse
-    password: "${HOMESERVER_DB_PASS}"
+    password: "${MATRIX_DB_PASSWORD}"
     database: synapse
     host: synapse-db
     cp_min: 5
     cp_max: 10
 log_config: "/data/localhost.log.config"
 media_store_path: /data/media_store
-registration_shared_secret: "${HOMESERVER_REG_KEY}"
-macaroon_secret_key: "${HOMESERVER_MAC_KEY}"
-form_secret: "${HOMESERVER_FORM_KEY}"
+registration_shared_secret: "${MATRIX_REGISTRATION_SECRET}"
+macaroon_secret_key: "${MATRIX_MACAROON_SECRET_KEY}"
+form_secret: "${MATRIX_FORM_SECRET}"
 report_stats: false

--- a/config/nextcloud/setup-office.sh
+++ b/config/nextcloud/setup-office.sh
@@ -13,20 +13,11 @@
 # wopi_callback_url overrides this — telling richdocuments to use the
 # Docker-internal hostname (http://nextcloud:80) for all WOPI callbacks.
 
-# Wait for Collabora to be reachable before configuring richdocuments.
-echo "Waiting for Collabora to be reachable..."
-RETRIES=0
-MAX_RETRIES=30
-while ! curl -sf http://collabora:9980/ > /dev/null 2>&1; do
-    RETRIES=$((RETRIES + 1))
-    if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
-        echo "WARNING: Collabora not reachable after ${MAX_RETRIES} attempts. Configuring anyway."
-        break
-    fi
-    sleep 2
-done
-if [ "$RETRIES" -lt "$MAX_RETRIES" ]; then
+WAITER="${HOMEFORGE_WAITER:-/usr/local/bin/wait-for-db.sh}"
+if "$WAITER" http http://collabora:9980/ 90 "Collabora"; then
     echo "Collabora is reachable. Configuring richdocuments..."
+else
+    echo "WARNING: Collabora not reachable after wait window. Configuring anyway."
 fi
 
 php /var/www/html/occ app:enable richdocuments || true

--- a/config/nextcloud/startup-waiter.sh
+++ b/config/nextcloud/startup-waiter.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+WAITER="${HOMEFORGE_WAITER:-/usr/local/bin/wait-for-db.sh}"
+OCC="php /var/www/html/occ"
+
+"$WAITER" tcp db 3306 90 "Nextcloud MariaDB"
+
+STATUS_JSON="$($OCC status --output=json 2>/dev/null || true)"
+
+if echo "$STATUS_JSON" | grep -q '"installed":true'; then
+  echo "[nextcloud-startup] install detected"
+
+  if echo "$STATUS_JSON" | grep -q '"needsDbUpgrade":true'; then
+    echo "[nextcloud-startup] pending upgrade found"
+    $OCC upgrade --no-interaction
+    STATUS_JSON="$($OCC status --output=json 2>/dev/null || true)"
+  else
+    echo "[nextcloud-startup] no database upgrade needed"
+  fi
+
+  if echo "$STATUS_JSON" | grep -q '"maintenance":true'; then
+    echo "[nextcloud-startup] maintenance mode still enabled after startup checks" >&2
+  fi
+else
+  echo "[nextcloud-startup] fresh install or occ status unavailable; skipping upgrade"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -346,6 +346,7 @@ services:
       - ./scripts/wait-for-db.sh:/usr/local/bin/wait-for-db.sh:ro
       - ./config/matrix:/etc/synapse-config:ro
     environment:
+      - MATRIX_SERVER_NAME=${MATRIX_SERVER_NAME:-localhost}
       - MATRIX_REGISTRATION_SECRET_FILE=/run/secrets/matrix_registration_secret
       - MATRIX_MACAROON_SECRET_KEY_FILE=/run/secrets/matrix_macaroon_secret_key
       - MATRIX_FORM_SECRET_FILE=/run/secrets/matrix_form_secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
         limits:
           memory: 512m
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p\"$$(cat /run/secrets/mysql_root_password)\""]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -172,6 +172,8 @@ services:
     volumes:
       - ./data/nextcloud/html:/var/www/html
       - ./data/nextcloud/data:/var/www/nextcloud_data
+      - ./scripts/wait-for-db.sh:/usr/local/bin/wait-for-db.sh:ro
+      - ./config/nextcloud/startup-waiter.sh:/docker-entrypoint-hooks.d/before-starting/00-startup-waiter.sh:ro
       - ./config/nextcloud/setup-office.sh:/docker-entrypoint-hooks.d/before-starting/setup-office.sh:ro
       - ./config/nextcloud/setup-office-post-install.sh:/docker-entrypoint-hooks.d/post-installation/setup-office-post-install.sh:ro
     environment:
@@ -190,7 +192,7 @@ services:
       - nextcloud_admin_password
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
       collabora:
         condition: service_healthy
     deploy:
@@ -337,9 +339,11 @@ services:
     ports:
       - '8008:8008'
     depends_on:
-      - synapse-db
+      synapse-db:
+        condition: service_healthy
     volumes:
       - ./data/matrix/synapse:/data
+      - ./scripts/wait-for-db.sh:/usr/local/bin/wait-for-db.sh:ro
       - ./config/matrix:/etc/synapse-config:ro
     environment:
       - MATRIX_REGISTRATION_SECRET_FILE=/run/secrets/matrix_registration_secret
@@ -352,7 +356,7 @@ services:
       - matrix_macaroon_secret_key
       - matrix_form_secret
       - mysql_password
-    entrypoint: ["/bin/sh", "-c", "python3 /etc/synapse-config/gen_config.py && cp /etc/synapse-config/localhost.log.config /data/localhost.log.config && exec python -m synapse.app.homeserver -c /data/homeserver.yaml -c /data/localhost.log.config"]
+    entrypoint: ["/bin/sh", "/etc/synapse-config/entrypoint.sh"]
     restart: on-failure:5
     deploy:
       resources:

--- a/scripts/wait-for-db.sh
+++ b/scripts/wait-for-db.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -lt 4 ]; then
+  echo "usage: $0 <tcp|http> <target> <port|timeout> <timeout|label> [label]" >&2
+  exit 64
+fi
+
+MODE="$1"
+TARGET="$2"
+
+case "$MODE" in
+  tcp)
+    PORT="$3"
+    TIMEOUT="$4"
+    LABEL="${5:-$TARGET:$PORT}"
+    ;;
+  http)
+    PORT=""
+    TIMEOUT="$3"
+    LABEL="${4:-$TARGET}"
+    ;;
+  *)
+    echo "[waiter] unknown mode: $MODE" >&2
+    exit 64
+    ;;
+esac
+
+check_tcp() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$TARGET" "$PORT" <<'PY'
+import socket, sys
+host = sys.argv[1]
+port = int(sys.argv[2])
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.settimeout(1.5)
+try:
+    sock.connect((host, port))
+except OSError:
+    sys.exit(1)
+finally:
+    sock.close()
+PY
+    return $?
+  fi
+
+  if command -v php >/dev/null 2>&1; then
+    php -r '
+$host=$argv[1];
+$port=(int)$argv[2];
+$errno=0;
+$errstr="";
+$fp=@fsockopen($host,$port,$errno,$errstr,1.5);
+if ($fp === false) exit(1);
+fclose($fp);
+' "$TARGET" "$PORT"
+    return $?
+  fi
+
+  if command -v nc >/dev/null 2>&1; then
+    nc -z "$TARGET" "$PORT"
+    return $?
+  fi
+
+  echo "[waiter] no tcp probe available for $LABEL" >&2
+  exit 69
+}
+
+check_http() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsS --max-time 2 "$TARGET" >/dev/null
+    return $?
+  fi
+
+  if command -v wget >/dev/null 2>&1; then
+    wget -q -T 2 -O /dev/null "$TARGET"
+    return $?
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$TARGET" <<'PY'
+import sys, urllib.request
+try:
+    with urllib.request.urlopen(sys.argv[1], timeout=2) as response:
+        sys.exit(0 if response.status < 400 else 1)
+except Exception:
+    sys.exit(1)
+PY
+    return $?
+  fi
+
+  echo "[waiter] no http probe available for $LABEL" >&2
+  exit 69
+}
+
+echo "[waiter] waiting for $LABEL"
+
+ATTEMPT=0
+while [ "$ATTEMPT" -lt "$TIMEOUT" ]; do
+  if [ "$MODE" = "tcp" ]; then
+    check_tcp && {
+      echo "[waiter] ready: $LABEL"
+      exit 0
+    }
+  else
+    check_http && {
+      echo "[waiter] ready: $LABEL"
+      exit 0
+    }
+  fi
+
+  ATTEMPT=$((ATTEMPT + 1))
+  sleep 1
+done
+
+echo "[waiter] timeout after ${TIMEOUT}s: $LABEL" >&2
+exit 1


### PR DESCRIPTION
## Summary
- add shared waiter script for DB and dependency readiness
- gate Nextcloud and Synapse on healthy database startup
- run Nextcloud upgrade checks before app boot
- run Synapse migration helper before app boot
- fix Matrix template/env alignment required for startup

Closes #227

## Test plan
- sh -n on changed shell scripts
- docker compose config
- docker compose up -d nextcloud synapse
- verify project-s-nextcloud healthy
- verify project-s-matrix-server healthy
- inspect logs for waiter plus migration flow
