### PR TITLE
feat: host agent auto-start persistence (#228)

### DIFF
--- a/Project_S_Logs/53_Host_Agent_Autostart.md
+++ b/Project_S_Logs/53_Host_Agent_Autostart.md
@@ -120,3 +120,7 @@ Linux install will require root.
 macOS install will be user-level, no root.
 
 Linux and Windows command paths implemented, but not live-run on this macOS host.
+
+README follow-up:
+- clarified `boom.sh` starts Docker stack only
+- clarified host agent auto-start is separate optional step on macOS/Windows

--- a/Project_S_Logs/53_Host_Agent_Autostart.md
+++ b/Project_S_Logs/53_Host_Agent_Autostart.md
@@ -1,0 +1,122 @@
+# Host Agent Auto-Start
+
+**Date:** April 16, 2026  
+**Issue:** `#228`  
+**Branch:** `feat/host-agent-autostart-228`  
+**Status:** ✅ Done
+
+---
+
+## Problem
+
+Host agent lives, but not persist.
+
+After reboot:
+- metrics die
+- dashboard loses host data
+- user must restart agent by hand or via `boom.sh`
+
+---
+
+## Scope Questioning
+
+True 3-OS auto-start is easy to fake.
+Need smallest real slice.
+
+Chosen shape:
+- macOS: LaunchAgent
+- Linux: systemd system service
+- Windows: Task Scheduler `ONSTART`
+
+Reason:
+- real OS-native persistence
+- no external dependency manager
+- one binary command path
+
+---
+
+## CLI
+
+```bash
+./homeforge-agent --install-service
+./homeforge-agent --uninstall-service
+```
+
+Behavior by OS:
+- macOS installs plist into user LaunchAgents
+- Linux installs systemd unit into `/etc/systemd/system`
+- Windows creates scheduled task named `HomeForge Host Agent`
+
+---
+
+## Files Changed
+
+- `agent/main.go`
+- `agent/init/launchd.plist.tpl`
+- `agent/init/systemd.service.tpl`
+- `agent/README.md`
+- `README.md`
+
+---
+
+## Implementation
+
+### New flags
+
+```bash
+./homeforge-agent --install-service
+./homeforge-agent --uninstall-service
+```
+
+### macOS
+
+- installs `~/Library/LaunchAgents/com.homeforge.agent.plist`
+- uses `launchctl load -w`
+- uses user LaunchAgent
+- starts on login
+
+### Linux
+
+- installs `/etc/systemd/system/homeforge-agent.service`
+- runs `systemctl daemon-reload`
+- runs `systemctl enable`
+- starts immediately only if port `9101` is free
+
+### Windows
+
+- creates scheduled task `HomeForge Host Agent`
+- uses `schtasks`
+- trigger: `ONSTART`
+- run-as: `SYSTEM`
+
+### Safety
+
+- if port `9101` already busy, install still succeeds
+- service is registered
+- immediate start is skipped
+- this avoids failing when manual agent already running
+
+---
+
+## Validation
+
+- `go build ./...` — pass
+- `make test` — pass
+  Smoke test noisy when port `9101` already occupied by existing agent, but health and metrics checks still returned OK.
+- macOS `make build` — pass
+- macOS `./homeforge-agent --install-service` — pass
+- macOS plist created — pass
+- macOS `./homeforge-agent --uninstall-service` — pass
+- macOS plist removed — pass
+
+---
+
+## Notes
+
+Windows path least trusted.
+Will use official `schtasks /create` `ONSTART` flow.
+
+Linux install will require root.
+macOS install will be user-level, no root.
+
+Linux and Windows command paths implemented, but not live-run on this macOS host.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ chmod +x boom.sh
 
 **Best for:** Day-to-day restarts
 
+**Important:**
+- `boom.sh` starts Docker stack
+- `boom.sh` does **not** install OS auto-start for host metrics agent
+- macOS / Windows users who want host metrics after reboot must install agent separately
+
 ### Option B: The "Install" Script (Linux / First-Time Setup)
 
 ```bash
@@ -231,6 +236,11 @@ Accessible from anywhere via MagicDNS:
 
 Docker runs in a VM on macOS/Windows and can't read host metrics directly. Use the compiled Go agent for high-performance, zero-dependency monitoring.
 
+New user path:
+- run `boom.sh` first to start dashboard stack
+- if on macOS or Windows and you want real host metrics, install host agent too
+- Linux users do not need host agent for normal metrics
+
 ```bash
 # macOS/Windows only (Linux users get metrics automatically)
 cd agent
@@ -242,6 +252,12 @@ To install host auto-start:
 
 ```bash
 ./homeforge-agent --install-service
+```
+
+To remove host auto-start:
+
+```bash
+./homeforge-agent --uninstall-service
 ```
 
 **Dashboard shows:**

--- a/README.md
+++ b/README.md
@@ -238,6 +238,12 @@ make all
 ./homeforge-agent
 ```
 
+To install host auto-start:
+
+```bash
+./homeforge-agent --install-service
+```
+
 **Dashboard shows:**
 - 🍎 **macOS** / 🪟 **Windows** / 🐧 **Linux** badge
 - 🔵 **Agent Connected** indicator

--- a/agent/README.md
+++ b/agent/README.md
@@ -20,6 +20,23 @@ make release      # cross-compile all targets → dist/
 # Health:   http://localhost:9101/health
 ```
 
+## Service Install
+
+```bash
+./homeforge-agent --install-service
+./homeforge-agent --uninstall-service
+```
+
+| Platform | Install Target | Notes |
+|--------|--------|--------|
+| macOS | `~/Library/LaunchAgents/com.homeforge.agent.plist` | User LaunchAgent, starts on login |
+| Linux | `/etc/systemd/system/homeforge-agent.service` | Requires root, starts on boot |
+| Windows | Task Scheduler: `HomeForge Host Agent` | Requires elevated shell, starts on boot |
+
+Logs:
+- macOS / Linux: `/tmp/homeforge-agent.log`
+- Windows: Task Scheduler history / task last-run result
+
 ## Endpoints
 
 | Endpoint   | Response                          |

--- a/agent/init/launchd.plist.tpl
+++ b/agent/init/launchd.plist.tpl
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>{{LABEL}}</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>{{BINARY_PATH}}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>{{WORKING_DIR}}</string>
+    <key>StandardOutPath</key>
+    <string>{{LOG_PATH}}</string>
+    <key>StandardErrorPath</key>
+    <string>{{LOG_PATH}}</string>
+  </dict>
+</plist>

--- a/agent/init/systemd.service.tpl
+++ b/agent/init/systemd.service.tpl
@@ -1,0 +1,16 @@
+[Unit]
+Description=HomeForge Host Agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart={{BINARY_PATH}}
+WorkingDirectory={{WORKING_DIR}}
+Restart=always
+RestartSec=2
+StandardOutput=append:{{LOG_PATH}}
+StandardError=append:{{LOG_PATH}}
+
+[Install]
+WantedBy=multi-user.target

--- a/agent/main.go
+++ b/agent/main.go
@@ -7,11 +7,19 @@
 package main
 
 import (
+	"embed"
 	"encoding/json"
+	"errors"
+	"flag"
 	"fmt"
 	"log"
+	stdnet "net"
 	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -20,13 +28,21 @@ import (
 	"github.com/shirou/gopsutil/v3/host"
 	"github.com/shirou/gopsutil/v3/load"
 	"github.com/shirou/gopsutil/v3/mem"
-	"github.com/shirou/gopsutil/v3/net"
+	gopsutilnet "github.com/shirou/gopsutil/v3/net"
 )
 
 const (
-	port     = ":9101"
-	cacheTTL = 2 * time.Second
+	port              = ":9101"
+	cacheTTL          = 2 * time.Second
+	serviceLabel      = "com.homeforge.agent"
+	serviceTaskName   = "HomeForge Host Agent"
+	defaultAgentLog   = "/tmp/homeforge-agent.log"
+	launchAgentRel    = "Library/LaunchAgents/com.homeforge.agent.plist"
+	systemdServiceRel = "/etc/systemd/system/homeforge-agent.service"
 )
+
+//go:embed init/*
+var initTemplates embed.FS
 
 // --- JSON response types (must match dashboard expectations in app/api/stats/route.ts) ---
 
@@ -200,7 +216,7 @@ func isVirtualFS(fstype string) bool {
 }
 
 func collectNetwork() NetMetrics {
-	counters, err := net.IOCounters(false) // false = aggregate all interfaces
+	counters, err := gopsutilnet.IOCounters(false) // false = aggregate all interfaces
 	if err != nil || len(counters) == 0 {
 		return NetMetrics{}
 	}
@@ -331,9 +347,231 @@ func round1(f float64) float64 {
 	return float64(int(f*10+0.5)) / 10
 }
 
+func executablePath() (string, error) {
+	path, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved, nil
+	}
+	return path, nil
+}
+
+func renderTemplate(name string, values map[string]string) (string, error) {
+	raw, err := initTemplates.ReadFile(name)
+	if err != nil {
+		return "", err
+	}
+
+	out := string(raw)
+	for key, val := range values {
+		out = strings.ReplaceAll(out, "{{"+key+"}}", val)
+	}
+
+	return out, nil
+}
+
+func ensureDir(path string) error {
+	return os.MkdirAll(path, 0o755)
+}
+
+func writeFile(path string, content string, mode os.FileMode) error {
+	if err := ensureDir(filepath.Dir(path)); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), mode)
+}
+
+func runCommand(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func runCommandQuiet(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	return cmd.Run()
+}
+
+func agentPortBusy() bool {
+	ln, err := stdnet.Listen("tcp", port)
+	if err != nil {
+		return true
+	}
+	_ = ln.Close()
+	return false
+}
+
+func installLaunchd(binaryPath string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	plistPath := filepath.Join(home, launchAgentRel)
+	content, err := renderTemplate("init/launchd.plist.tpl", map[string]string{
+		"LABEL":       serviceLabel,
+		"BINARY_PATH": binaryPath,
+		"WORKING_DIR": filepath.Dir(binaryPath),
+		"LOG_PATH":    defaultAgentLog,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := writeFile(plistPath, content, 0o644); err != nil {
+		return err
+	}
+
+	_ = runCommandQuiet("launchctl", "unload", "-w", plistPath)
+	if err := runCommand("launchctl", "load", "-w", plistPath); err != nil {
+		return err
+	}
+	if agentPortBusy() {
+		log.Printf("LaunchAgent installed. Port %s already busy, skipping immediate start.", port)
+		return nil
+	}
+
+	log.Printf("LaunchAgent installed at %s", plistPath)
+	return nil
+}
+
+func uninstallLaunchd() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	plistPath := filepath.Join(home, launchAgentRel)
+	_ = runCommandQuiet("launchctl", "unload", "-w", plistPath)
+	if err := os.Remove(plistPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	log.Printf("LaunchAgent removed from %s", plistPath)
+	return nil
+}
+
+func installSystemd(binaryPath string) error {
+	if os.Geteuid() != 0 {
+		return errors.New("systemd install requires root")
+	}
+
+	content, err := renderTemplate("init/systemd.service.tpl", map[string]string{
+		"BINARY_PATH": binaryPath,
+		"WORKING_DIR": filepath.Dir(binaryPath),
+		"LOG_PATH":    defaultAgentLog,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := writeFile(systemdServiceRel, content, 0o644); err != nil {
+		return err
+	}
+	if err := runCommand("systemctl", "daemon-reload"); err != nil {
+		return err
+	}
+	if err := runCommand("systemctl", "enable", "homeforge-agent.service"); err != nil {
+		return err
+	}
+	if agentPortBusy() {
+		log.Printf("systemd service installed. Port %s already busy, skipping immediate start.", port)
+		return nil
+	}
+	if err := runCommand("systemctl", "start", "homeforge-agent.service"); err != nil {
+		return err
+	}
+
+	log.Printf("systemd service installed at %s", systemdServiceRel)
+	return nil
+}
+
+func uninstallSystemd() error {
+	if os.Geteuid() != 0 {
+		return errors.New("systemd uninstall requires root")
+	}
+
+	_ = runCommand("systemctl", "disable", "--now", "homeforge-agent.service")
+	if err := os.Remove(systemdServiceRel); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := runCommand("systemctl", "daemon-reload"); err != nil {
+		return err
+	}
+
+	log.Printf("systemd service removed from %s", systemdServiceRel)
+	return nil
+}
+
+func installWindowsTask(binaryPath string) error {
+	taskRun := fmt.Sprintf("\"%s\"", binaryPath)
+	return runCommand("schtasks", "/create", "/tn", serviceTaskName, "/tr", taskRun, "/sc", "onstart", "/ru", "SYSTEM", "/rl", "HIGHEST", "/f")
+}
+
+func uninstallWindowsTask() error {
+	return runCommand("schtasks", "/delete", "/tn", serviceTaskName, "/f")
+}
+
+func installService() error {
+	binaryPath, err := executablePath()
+	if err != nil {
+		return err
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		return installLaunchd(binaryPath)
+	case "linux":
+		return installSystemd(binaryPath)
+	case "windows":
+		return installWindowsTask(binaryPath)
+	default:
+		return fmt.Errorf("service install unsupported on %s", runtime.GOOS)
+	}
+}
+
+func uninstallService() error {
+	switch runtime.GOOS {
+	case "darwin":
+		return uninstallLaunchd()
+	case "linux":
+		return uninstallSystemd()
+	case "windows":
+		return uninstallWindowsTask()
+	default:
+		return fmt.Errorf("service uninstall unsupported on %s", runtime.GOOS)
+	}
+}
+
 // --- Main ---
 
 func main() {
+	installFlag := flag.Bool("install-service", false, "Install the host agent as an OS-native service")
+	uninstallFlag := flag.Bool("uninstall-service", false, "Remove the OS-native host agent service")
+	flag.Parse()
+
+	if *installFlag && *uninstallFlag {
+		log.Fatal("use only one of --install-service or --uninstall-service")
+	}
+
+	if *installFlag {
+		if err := installService(); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
+	if *uninstallFlag {
+		if err := uninstallService(); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
 	http.HandleFunc("/metrics", handleMetrics)
 	http.HandleFunc("/health", handleHealth)
 


### PR DESCRIPTION
## Summary
- add host-agent service install and uninstall commands
- support macOS LaunchAgent, Linux systemd, and Windows Task Scheduler
- update docs and add project log for issue #228

Closes #228

## Test plan
- [x] `go build ./...`
- [x] `make test`
- [x] macOS `./homeforge-agent --install-service`
- [x] macOS `./homeforge-agent --uninstall-service`