### PR TITLE
docs: clarify host agent start and stop flow

### DIFF
--- a/Project_S_Logs/53_Host_Agent_Autostart.md
+++ b/Project_S_Logs/53_Host_Agent_Autostart.md
@@ -124,3 +124,4 @@ Linux and Windows command paths implemented, but not live-run on this macOS host
 README follow-up:
 - clarified `boom.sh` starts Docker stack only
 - clarified host agent auto-start is separate optional step on macOS/Windows
+- added explicit stop commands for stack and manual host-agent run

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ chmod +x boom.sh
 
 **Best for:** Day-to-day restarts
 
+To stop stack:
+
+```bash
+docker compose down
+```
+
 **Important:**
 - `boom.sh` starts Docker stack
 - `boom.sh` does **not** install OS auto-start for host metrics agent
@@ -246,6 +252,13 @@ New user path:
 cd agent
 make all
 ./homeforge-agent
+```
+
+To stop manual agent run:
+
+```bash
+# same terminal
+Ctrl+C
 ```
 
 To install host auto-start:

--- a/agent/README.md
+++ b/agent/README.md
@@ -20,6 +20,13 @@ make release      # cross-compile all targets → dist/
 # Health:   http://localhost:9101/health
 ```
 
+To stop manual run:
+
+```bash
+# same terminal
+Ctrl+C
+```
+
 ## Service Install
 
 ```bash


### PR DESCRIPTION
## Summary
- add explicit stack stop command after `boom.sh`
- add explicit `Ctrl+C` stop instructions for manual host-agent runs
- update host-agent log note for the docs follow-up

## Test plan
- [x] docs reviewed locally
- [x] commands match current README and agent flow