### PR TITLE
docs: preserve missing project logs

### DIFF
--- a/Project_S_Logs/02_Project_Roadmap.md
+++ b/Project_S_Logs/02_Project_Roadmap.md
@@ -700,3 +700,12 @@
 * Duration 0.5 days
 * Owner Author
 * Status ✅ Complete — Merged via PR #208
+
+### Task 65 Backup UI Polish and Theme Alignment
+* Category UI Polish
+* Description Refine the Backup tab to match Metrics-page quality: stat pills, skeleton loading, mobile card view, real progress, and polished empty state.
+* Dependencies Issue #211, Log 54
+* Priority Medium
+* Duration 0.5 day
+* Owner Author
+* Status ✅ Complete — Merged via PR #214

--- a/Project_S_Logs/39_SSL_TLS_Configuration.md
+++ b/Project_S_Logs/39_SSL_TLS_Configuration.md
@@ -1,4 +1,4 @@
-# 38 — SSL/TLS Configuration (Phase 11)
+# 39 — SSL/TLS Configuration (Phase 11)
 
 Date: 2026-04-10
 Author: Author

--- a/Project_S_Logs/54_Backup_UI_Polish_and_Theme_Alignment.md
+++ b/Project_S_Logs/54_Backup_UI_Polish_and_Theme_Alignment.md
@@ -1,0 +1,71 @@
+# 54 — Backup UI Polish and Theme Alignment (Issue #211)
+
+**Date:** April 14, 2026  
+**Author:** Gemini CLI  
+**Related Issue:** #211  
+**PR:** #214  
+**Status:** ✅ Merged to `main`
+
+---
+
+## Context
+
+Following the core functionality fixes in Log 47, the Backup tab required a "premium" UI polish and architectural alignment with the rest of the dashboard (specifically the Metrics page) to ensure a seamless user experience for the v1.0 release.
+
+This log was backfilled later to preserve the work without reusing an already-taken log number.
+
+## Enhancements Applied
+
+### 1. Theme Alignment (Metrics Sync)
+
+The Backup page was redesigned to mirror the **Metrics** page layout patterns:
+- **Header:** Standardized with small title and "Real-time · 5s refresh" subtext.
+- **Stat Pills:** Added a horizontal row of high-level metrics (Total Storage, Last Run Age, Snapshot Count, Host Disk Usage).
+- **Card Design:** Transitioned to `bg-secondary/5` cards with 11px uppercase `SectionHeader` components.
+- **Data Density:** Refined table padding and font sizes to match the high-density "Containers" list on the Metrics page.
+
+### 2. Loading UX (Skeletons)
+
+- Integrated `@/components/ui/skeleton` into the initial data fetch flow.
+- Table rows and status fields now pulse during the first load, eliminating layout shifts and providing immediate visual structure.
+
+### 3. Mobile-First "Card List"
+
+- Replaced the rigid desktop table with a responsive **Card View** for screens smaller than 768px.
+- Each backup now stacks as a detailed card with Snapshot ID, Status, Size, and Service pills, optimized for vertical scrolling on mobile devices.
+
+### 4. Dual-State Progress Bar
+
+- Implemented a smart progress indicator in the "Create Snapshot" card.
+- **Phase 1 (Preparing):** Pulsing indeterminate state while containers are being paused.
+- **Phase 2 (Compressing/Encrypting):** Simulated 0-95% progress bar providing real-time feedback during the long-running Restic capture process.
+
+### 5. Storage Visualization
+
+- Added a real-time **Host Disk Usage** gauge.
+- Integrated with the `/api/stats` endpoint to show the current root filesystem state.
+- **Color Logic:** Emerald (<70%), Amber (70-90%), and pulsing Rose (>90%) to proactively warn of potential backup failures due to disk space.
+
+### 6. Empty State Illustration
+
+- Replaced the "No snapshots found" text with a professional empty state.
+- Features a centered database icon with a soft glow, a friendly call-to-action message, and a direct "Run First Backup" button.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `components/dashboard/backup-section.tsx` | Complete UI overhaul for theme alignment, responsive cards, skeletons, and progress tracking. |
+
+---
+
+## Acceptance Criteria
+
+- [x] Header matches Metrics page styling
+- [x] Stat pills aggregate cumulative data correctly
+- [x] Table rows pulse on initial load
+- [x] Backups stack as cards on mobile
+- [x] Progress bar animates during active backup
+- [x] Disk usage gauge reflects host machine state


### PR DESCRIPTION
## Summary
- preserve the leftover Backup UI polish log as new Log 54
- rename duplicate SSL/TLS log from 38 to 39 to fix numbering
- update roadmap to reference the preserved backup log

## Test plan
- [x] log numbering reviewed locally
- [x] roadmap references reviewed locally
- [x] no code paths changed