### PR TITLE
fix: Resolve GitHub Pages build crash (UPS data TypeError)

### DIFF
--- a/Dashboard/Dashboard1/app/page.tsx
+++ b/Dashboard/Dashboard1/app/page.tsx
@@ -60,7 +60,13 @@ export default function HomePage() {
     ],
     disks: [
       { mount: "/", total: "1TB", used: "320GB", avail: "680GB", usePerc: 32, device: "/dev/sda1" }
-    ]
+    ],
+    ups: {
+      batteryPerc: 100,
+      loadPerc: 12,
+      runtimeMin: 45,
+      status: "OL"
+    }
   } : undefined
 
   useEffect(() => {

--- a/Dashboard/Dashboard1/components/dashboard/metrics-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/metrics-section.tsx
@@ -665,7 +665,7 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
             )}
 
             {/* UPS Status */}
-            {stats?.ups?.batteryPerc !== null && stats && (
+            {stats?.ups && stats.ups.batteryPerc !== null && (
               <div>
                 <SectionHeader title="UPS" />
                 <div className="bg-secondary/5 rounded-lg p-3">


### PR DESCRIPTION
Closes #237. Re-applies the fix for the prerender error found on main. Guards the UPS property access and provides mock UPS data for the landing page.