### PR TITLE
feat: network segmentation — frontend = Traefik+Dashboard+Tailscale only (#242)

### DIFF
--- a/Project_S_Logs/00_Master_Implementation_Plan.md
+++ b/Project_S_Logs/00_Master_Implementation_Plan.md
@@ -14,7 +14,9 @@
 | Feature | Status | Issue | Branch | Log |
 |---|---|---|---|---|
 | Compiled Host Agent (Go) | ✅ Done | #225 | `feat/compiled-host-agent-225` | #51 |
-| Migration Waiter | ⏳ Planned | - | - | - |
+| Migration Waiter Phase 9 | ✅ Merged | #239 | `feat/migration-waiter-phase9-239` | #55 |
+| Architecture SSOT | ✅ Merged | #241 | `docs/architecture-ssot-241` | #56 |
+| Network Segmentation | ⏳ PR Open | #242 | `feat/network-segmentation-242` | #57 |
 | Host Agent Auto-Start | ⏳ Planned | - | - | - |
 
 ### v1.0 Features Shipped

--- a/Project_S_Logs/57_Network_Segmentation.md
+++ b/Project_S_Logs/57_Network_Segmentation.md
@@ -1,0 +1,78 @@
+# 57 — Network Segmentation (Issue #242)
+
+**Date:** April 16, 2026
+**Issue:** `#242`
+**Branch:** `feat/network-segmentation-242`
+**Status:** ⏳ PR Open
+
+---
+
+## Problem
+
+15 services unnecessarily joined to the `frontend` Docker network. Only Traefik, Dashboard, and Tailscale are true entry points. The wider `frontend` membership increases blast radius: if any service is compromised, it has unnecessary reach to the ingress network.
+
+---
+
+## Goal
+
+`frontend` = Traefik + Dashboard + Tailscale only.  
+All other user-facing services → `backend` only.  
+Traefik (on both networks) routes to services via `backend` — no disruption to routing.
+
+---
+
+## What Changed
+
+Single file: `docker-compose.yml` — network membership only. No port changes, no code changes.
+
+| Service | Before | After |
+|---------|--------|-------|
+| jellyfin | frontend, backend | backend |
+| collabora | frontend, backend | backend |
+| theia | frontend, backend | backend |
+| synapse | frontend, backend, database | backend, database |
+| element | frontend | backend |
+| open-webui | frontend, backend | backend |
+| kiwix-manager | frontend | backend |
+| openvpn-ui | frontend, backend | backend |
+| homeforge-backup | frontend, backend, database | backend, database |
+
+## Unchanged
+
+| Service | Networks | Reason |
+|---------|----------|--------|
+| traefik | frontend, backend | Entry point — needs both |
+| dashboard | frontend, backend | Control plane entry point |
+| tailscale | frontend | Remote access overlay |
+| vaultwarden | backend | Already correct |
+| nextcloud | backend, database | Already correct |
+| ollama | backend | Already correct |
+| kiwix | backend | Already correct |
+| openvpn | backend | Already correct |
+| socket-proxy | backend | Already correct |
+| db (mariadb) | database | Already correct |
+| synapse-db (postgres) | database | Already correct |
+
+---
+
+## Why This Is Safe
+
+Traefik is on `frontend` AND `backend`. It discovers services via Docker labels regardless of which shared network it uses to reach them. Moving services off `frontend` but keeping them on `backend` means Traefik routes via `backend` — identical behaviour, smaller blast radius.
+
+Element and kiwix-manager were `frontend`-only before (no `backend`). They're now on `backend` so Traefik can route to them. Previously routing worked because they were on `frontend` with Traefik; now it works because they're on `backend` with Traefik.
+
+---
+
+## Out of Scope
+
+- Port binding to `127.0.0.1` (breaks dashboard iframes — separate issue)
+- Removing direct `ports:` from user-facing services (same reason)
+- Any dashboard code changes
+
+---
+
+## Files Changed
+
+- `docker-compose.yml`
+- `Project_S_Logs/57_Network_Segmentation.md` (this file)
+- `Project_S_Logs/00_Master_Implementation_Plan.md`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     image: jellyfin/jellyfin:10.10.6
     container_name: project-s-jellyfin
     networks:
-      - frontend
       - backend
     ports:
       - '8096:8096'
@@ -222,7 +221,6 @@ services:
     image: collabora/code:24.04.10.2.1
     container_name: project-s-collabora
     networks:
-      - frontend
       - backend
     ports:
       - '9980:9980'
@@ -269,7 +267,6 @@ services:
     image: ghcr.io/eclipse-theia/theia-ide/theia-ide:latest  # Theia only publishes :latest on GHCR
     container_name: project-s-theia
     networks:
-      - frontend
       - backend
     ports:
       - '3030:3000'
@@ -333,7 +330,6 @@ services:
     image: matrixdotorg/synapse:v1.120.0
     container_name: project-s-matrix-server
     networks:
-      - frontend
       - backend
       - database
     ports:
@@ -382,7 +378,7 @@ services:
     image: vectorim/element-web:v1.11.90
     container_name: project-s-matrix-client
     networks:
-      - frontend
+      - backend
     ports:
       - '8082:80'
     volumes:
@@ -434,7 +430,6 @@ services:
     image: ghcr.io/open-webui/open-webui:0.8.12
     container_name: project-s-open-webui
     networks:
-      - frontend
       - backend
     ports:
       - '8085:8080'
@@ -543,7 +538,7 @@ services:
     container_name: project-s-kiwix-manager
     user: "${UID:-1000}:${GID:-1000}"
     networks:
-      - frontend
+      - backend
     ports:
       - '8086:80'
     volumes:
@@ -592,7 +587,6 @@ services:
     image: d3vilh/openvpn-ui:latest
     container_name: project-s-openvpn-ui
     networks:
-      - frontend
       - backend
     ports:
       - '8090:8080'
@@ -669,7 +663,6 @@ services:
     networks:
       - backend
       - database
-      - frontend
     environment:
       - NODE_ENV=production
       - BACKUP_PORT=3070

--- a/docs/superpowers/plans/2026-04-16-network-segmentation.md
+++ b/docs/superpowers/plans/2026-04-16-network-segmentation.md
@@ -1,0 +1,106 @@
+# Network Segmentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tighten Docker network membership so `frontend` = Traefik + Dashboard + Tailscale only; all user-facing services move to `backend` only.
+
+**Architecture:** Single file change (`docker-compose.yml`) — remove `frontend` from 9 services, add `backend` to 2 that were frontend-only. No port changes, no code changes.
+
+**Tech Stack:** Docker Compose YAML only.
+
+---
+
+## File Map
+
+| File | Action |
+|------|--------|
+| `docker-compose.yml` | Modify — network membership for 9 services |
+| `Project_S_Logs/57_Network_Segmentation.md` | Create — implementation log |
+| `Project_S_Logs/00_Master_Implementation_Plan.md` | Modify — add #242 to v1.0.1 table |
+
+---
+
+## Task 1: Apply network membership changes
+
+**Files:**
+- Modify: `docker-compose.yml`
+
+Changes (9 services):
+
+| Service | From | To |
+|---------|------|----|
+| jellyfin | frontend, backend | backend |
+| collabora | frontend, backend | backend |
+| theia | frontend, backend | backend |
+| synapse | frontend, backend, database | backend, database |
+| element | frontend | backend |
+| open-webui | frontend, backend | backend |
+| kiwix-manager | frontend | backend |
+| openvpn-ui | frontend, backend | backend |
+| homeforge-backup | frontend, backend, database | backend, database |
+
+- [ ] **Step 1: Apply all 9 network changes to docker-compose.yml**
+
+Edit each service's `networks:` block as per the table above.
+
+- [ ] **Step 2: Verify frontend has only 3 services**
+
+```bash
+grep -B30 'networks:' docker-compose.yml | grep -E '(container_name|^\s+- frontend)'
+```
+
+Expected: only `project-s-traefik`, `project-s-dashboard`, `project-s-tailscale` reference `- frontend`.
+
+- [ ] **Step 3: Validate compose config parses**
+
+```bash
+docker compose config --quiet
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "feat: tighten network segmentation — frontend = Traefik+Dashboard+Tailscale only (#242)"
+```
+
+---
+
+## Task 2: Add Log 57 + update roadmap
+
+**Files:**
+- Create: `Project_S_Logs/57_Network_Segmentation.md`
+- Modify: `Project_S_Logs/00_Master_Implementation_Plan.md`
+
+- [ ] **Step 1: Create Log 57**
+
+- [ ] **Step 2: Update roadmap v1.0.1 table**
+
+Add row: `| Network Segmentation | ⏳ PR Open | #242 | feat/network-segmentation-242 | #57 |`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Project_S_Logs/57_Network_Segmentation.md \
+  Project_S_Logs/00_Master_Implementation_Plan.md
+git commit -m "docs: add Log 57 and update roadmap for network segmentation (#242)"
+```
+
+---
+
+## Task 3: Push + open PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/network-segmentation-242
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "feat: network segmentation — frontend = Traefik+Dashboard+Tailscale only (#242)" \
+  --body "..."
+```

--- a/docs/superpowers/specs/2026-04-16-network-segmentation-design.md
+++ b/docs/superpowers/specs/2026-04-16-network-segmentation-design.md
@@ -1,0 +1,86 @@
+# Network Segmentation & Port Hardening — Design Spec
+
+**Issue:** #242
+**Date:** 2026-04-16
+**Branch:** `feat/network-segmentation-242`
+**Scope:** Network membership tightening only (port binding hardening = separate issue)
+
+---
+
+## Problem
+
+15 services unnecessarily joined to `frontend` network. Traefik + Dashboard are the only true entry points — all other services should communicate via `backend` only. Current state creates a wider blast radius if any service is compromised.
+
+---
+
+## Goal
+
+`frontend` network = Traefik + Dashboard + Tailscale only.  
+All user-facing services move to `backend` only.  
+Traefik (on both networks) routes to services via `backend` — no disruption.
+
+---
+
+## Single File Changed
+
+`docker-compose.yml` — network membership only. No port changes, no code changes.
+
+---
+
+## Network Changes
+
+| Service | Container | Current Networks | New Networks |
+|---------|-----------|-----------------|-------------|
+| jellyfin | project-s-jellyfin | frontend, backend | **backend** |
+| collabora | project-s-collabora | frontend, backend | **backend** |
+| theia | project-s-theia | frontend, backend | **backend** |
+| synapse | project-s-matrix-server | frontend, backend, database | **backend, database** |
+| element | project-s-matrix-client | frontend | **backend** |
+| open-webui | project-s-open-webui | frontend, backend | **backend** |
+| kiwix-manager | project-s-kiwix-manager | frontend | **backend** |
+| openvpn-ui | project-s-openvpn-ui | frontend, backend | **backend** |
+| homeforge-backup | homeforge-backup | frontend, backend, database | **backend, database** |
+
+## Unchanged
+
+| Service | Networks | Reason |
+|---------|----------|--------|
+| traefik | frontend, backend | Entry point — needs both |
+| dashboard | frontend, backend | Control plane entry point |
+| tailscale | frontend | Remote access overlay — entry point |
+| vaultwarden | backend | Already correct |
+| nextcloud | backend, database | Already correct |
+| ollama | backend | Already correct |
+| kiwix | backend | Already correct |
+| openvpn | backend | Already correct |
+| socket-proxy | backend | Already correct |
+| db (mariadb) | database | Already correct |
+| synapse-db (postgres) | database | Already correct |
+
+---
+
+## Why This Is Safe
+
+Traefik is on `frontend` AND `backend`. It discovers services via Docker labels regardless of which shared network it uses to reach them. Moving services off `frontend` but keeping them on `backend` means Traefik routes to them via `backend` — identical behaviour, smaller blast radius.
+
+---
+
+## Verification After Change
+
+```bash
+# Confirm traefik can still route to all services
+docker compose config | grep -A5 "networks:"
+
+# Confirm frontend has only 3 services
+docker network inspect homeLabbing_frontend | grep -i "name"
+```
+
+Expected: frontend contains only traefik, dashboard, tailscale containers.
+
+---
+
+## Out of Scope
+
+- Port binding to `127.0.0.1` (breaks dashboard iframes — separate issue)
+- Removing direct `ports:` from user-facing services (same reason)
+- Any dashboard code changes


### PR DESCRIPTION
## Summary

- Removes 9 services from `frontend` network — only Traefik, Dashboard, Tailscale remain on `frontend`
- Services now reach Traefik via `backend` (Traefik is on both networks — identical routing behaviour)
- element and kiwix-manager were frontend-only; both now on `backend` so Traefik can still reach them
- Single file changed: `docker-compose.yml` (network membership only — no ports, no code)

## Test plan

- [ ] `docker compose config --quiet` — no errors
- [ ] `docker network inspect homeLabbing_frontend` — shows only traefik, dashboard, tailscale
- [ ] All Traefik routes still resolve after `docker compose up -d`

Closes #242