### PR TITLE
fix(security): eliminate RCE — execFileSync + service whitelist in backup-sidecar (ref #249)

### DIFF
--- a/backup-sidecar/src/docker.ts
+++ b/backup-sidecar/src/docker.ts
@@ -1,8 +1,12 @@
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
+
+function dockerCmd(args: string[]): void {
+  execFileSync('docker', args, { stdio: 'ignore' })
+}
 
 export function pauseContainer(containerName: string) {
   try {
-    execSync(`docker pause ${containerName}`, { stdio: 'ignore' })
+    dockerCmd(['pause', containerName])
   } catch (e) {
     console.warn(`Failed to pause ${containerName}: ${e}`)
   }
@@ -10,7 +14,7 @@ export function pauseContainer(containerName: string) {
 
 export function unpauseContainer(containerName: string) {
   try {
-    execSync(`docker unpause ${containerName}`, { stdio: 'ignore' })
+    dockerCmd(['unpause', containerName])
   } catch (e) {
     console.warn(`Failed to unpause ${containerName}: ${e}`)
   }
@@ -18,7 +22,7 @@ export function unpauseContainer(containerName: string) {
 
 export function stopContainer(containerName: string) {
   try {
-    execSync(`docker stop ${containerName}`, { stdio: 'ignore' })
+    dockerCmd(['stop', containerName])
   } catch (e) {
     console.warn(`Failed to stop ${containerName}: ${e}`)
   }
@@ -26,7 +30,7 @@ export function stopContainer(containerName: string) {
 
 export function startContainer(containerName: string) {
   try {
-    execSync(`docker start ${containerName}`, { stdio: 'ignore' })
+    dockerCmd(['start', containerName])
   } catch (e) {
     console.warn(`Failed to start ${containerName}: ${e}`)
   }

--- a/backup-sidecar/src/restore.ts
+++ b/backup-sidecar/src/restore.ts
@@ -1,5 +1,5 @@
 import { stopContainer, startContainer } from './docker'
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 import { getDb } from './db'
@@ -13,8 +13,12 @@ const containerMap: Record<string, string> = {
   vaultwarden: 'project-s-vaultwarden'
 }
 
+// Strict whitelist — reject any service name not explicitly known
+const ALLOWED_SERVICES = new Set(Object.keys(containerMap))
+
 const RESTIC_REPO = process.env.RESTIC_REPO || '/data/backups/restic'
 const RESTIC_PASSWORD_FILE = process.env.RESTIC_PASSWORD_FILE || '/data/secrets/restic_password'
+const SNAPSHOTS_BASE = '/snapshots'
 
 function resticEnv(): Record<string, string> {
   return {
@@ -25,12 +29,10 @@ function resticEnv(): Record<string, string> {
 }
 
 function restic(args: string[], opts: { cwd?: string } = {}): string {
-  const cmd = `restic ${args.join(' ')}`
-  return execSync(cmd, {
+  return execFileSync('restic', args, {
     ...opts,
     env: resticEnv(),
     encoding: 'utf-8',
-    stdio: ['pipe', 'pipe', 'pipe'],
   }).trim()
 }
 
@@ -46,16 +48,32 @@ export async function runRestoreJob(jobId: string, backupRow: any, services: str
   restic(['restore', snapshotId, '--target', restoreDir])
 
   for (const service of services) {
-    const containerName = containerMap[service] || `project-s-${service}`
-    const snapshotPath = `/snapshots/${service}`
+    if (!ALLOWED_SERVICES.has(service)) {
+      console.warn(`Unknown service "${service}" — skipping`)
+      continue
+    }
+
+    const containerName = containerMap[service]
+    const snapshotPath = path.resolve(SNAPSHOTS_BASE, service)
     const serviceRestore = path.join(restoreDir, service)
+
+    // Boundary check — prevent path traversal via crafted service name
+    if (!snapshotPath.startsWith(SNAPSHOTS_BASE + path.sep)) {
+      console.warn(`Path traversal attempt for service "${service}" — skipping`)
+      continue
+    }
 
     if (!fs.existsSync(serviceRestore)) continue
 
     stopContainer(containerName)
     try {
-      execSync(`rm -rf ${snapshotPath}/*`, { stdio: 'ignore' })
-      execSync(`cp -a ${serviceRestore}/. ${snapshotPath}/`, { stdio: 'ignore' })
+      // Clear destination without spawning a shell
+      if (fs.existsSync(snapshotPath)) {
+        for (const entry of fs.readdirSync(snapshotPath)) {
+          fs.rmSync(path.join(snapshotPath, entry), { recursive: true, force: true })
+        }
+      }
+      execFileSync('cp', ['-a', `${serviceRestore}/.`, `${snapshotPath}/`], { stdio: 'ignore' })
     } finally {
       startContainer(containerName)
     }

--- a/backup-sidecar/src/snapshot.ts
+++ b/backup-sidecar/src/snapshot.ts
@@ -1,5 +1,5 @@
 import { pauseContainer, unpauseContainer } from './docker'
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 import { getDb } from './db'
@@ -13,8 +13,12 @@ const containerMap: Record<string, string> = {
   vaultwarden: 'project-s-vaultwarden'
 }
 
+// Strict whitelist — 'media' allowed for backup but has no container to pause
+const ALLOWED_SERVICES = new Set([...Object.keys(containerMap), 'media'])
+
 const RESTIC_REPO = process.env.RESTIC_REPO || '/data/backups/restic'
 const RESTIC_PASSWORD_FILE = process.env.RESTIC_PASSWORD_FILE || '/data/secrets/restic_password'
+const SNAPSHOTS_BASE = '/snapshots'
 
 function resticEnv(): Record<string, string> {
   return {
@@ -25,12 +29,10 @@ function resticEnv(): Record<string, string> {
 }
 
 function restic(args: string[], opts: { cwd?: string } = {}): string {
-  const cmd = `restic ${args.join(' ')}`
-  return execSync(cmd, {
+  return execFileSync('restic', args, {
     ...opts,
     env: resticEnv(),
     encoding: 'utf-8',
-    stdio: ['pipe', 'pipe', 'pipe'],
   }).trim()
 }
 
@@ -41,11 +43,11 @@ export async function initResticRepo() {
   }
   console.log('Initializing Restic repository...')
   fs.mkdirSync(RESTIC_REPO, { recursive: true })
-  // Generate password if not present
   const pwDir = path.dirname(RESTIC_PASSWORD_FILE)
   fs.mkdirSync(pwDir, { recursive: true })
   if (!fs.existsSync(RESTIC_PASSWORD_FILE)) {
-    const pw = execSync('openssl rand -hex 32').toString().trim()
+    // execFileSync with array args — no shell injection possible
+    const pw = execFileSync('openssl', ['rand', '-hex', '32'], { encoding: 'utf-8' }).trim()
     fs.writeFileSync(RESTIC_PASSWORD_FILE, pw)
   }
   restic(['init'])
@@ -63,9 +65,20 @@ export async function runBackupJob(jobId: string, services: string[], includeMed
     if (includeMedia) backupServices.push('media')
 
     for (const service of backupServices) {
-      const containerName = containerMap[service] || `project-s-${service}`
-      const snapshotPath = `/snapshots/${service}`
+      if (!ALLOWED_SERVICES.has(service)) {
+        console.warn(`Unknown service "${service}" — skipping`)
+        continue
+      }
+
+      const containerName = containerMap[service]
+      const snapshotPath = path.resolve(SNAPSHOTS_BASE, service)
       const serviceStaging = path.join(stagingDir, service)
+
+      // Boundary check — prevent path traversal
+      if (!snapshotPath.startsWith(SNAPSHOTS_BASE + path.sep)) {
+        console.warn(`Path traversal attempt for service "${service}" — skipping`)
+        continue
+      }
 
       if (!fs.existsSync(snapshotPath)) continue
 
@@ -73,23 +86,29 @@ export async function runBackupJob(jobId: string, services: string[], includeMed
 
       if (service === 'mariadb') {
         try {
-          execSync(`docker exec project-s-nextcloud-db sh -c 'exec mysqldump --all-databases -uroot -p"$MYSQL_ROOT_PASSWORD" > /var/lib/mysql/dump.sql'`, { stdio: 'ignore' })
+          // Container name and shell command are hardcoded — no user input involved
+          // execFileSync prevents host-level shell injection; sh runs inside the container
+          execFileSync(
+            'docker',
+            ['exec', 'project-s-nextcloud-db', 'sh', '-c',
+              'exec mysqldump --all-databases -uroot -p"$MYSQL_ROOT_PASSWORD" > /var/lib/mysql/dump.sql'],
+            { stdio: 'ignore' }
+          )
         } catch (e) { console.warn('mysqldump failed', e) }
       }
 
       const startPause = Date.now()
-      if (service !== 'media') pauseContainer(containerName)
+      if (service !== 'media' && containerName) pauseContainer(containerName)
 
       try {
-        execSync(`cp -a ${snapshotPath}/. ${serviceStaging}/`, { stdio: 'ignore' })
+        execFileSync('cp', ['-a', `${snapshotPath}/.`, `${serviceStaging}/`], { stdio: 'ignore' })
       } finally {
-        if (service !== 'media') unpauseContainer(containerName)
+        if (service !== 'media' && containerName) unpauseContainer(containerName)
         const duration = Date.now() - startPause
         if (service !== 'media') console.log(`Paused ${containerName} for ${duration}ms`)
       }
     }
 
-    // Run Restic backup
     console.log(`Running Restic backup for job ${jobId}...`)
     const output = restic(['backup', stagingDir, `--tag=job-${jobId}`, '--json'])
     const result = JSON.parse(output)


### PR DESCRIPTION
## What

Eliminates command injection / RCE vectors C1 and C2 from the security audit (ref #249).

## Changes

### `backup-sidecar/src/docker.ts`
- Replaced all 4 `execSync(\`docker <cmd> ${containerName}\`)` calls with `execFileSync('docker', [cmd, containerName])`
- No shell spawned → containerName cannot inject shell metacharacters

### `backup-sidecar/src/restore.ts`
- `restic()` fn: `execSync(\`restic ${args.join(' ')}\`)` → `execFileSync('restic', args)`
- `rm -rf ${snapshotPath}/*` → `fs.readdirSync` + `fs.rmSync` loop (no shell)
- `cp -a` → `execFileSync('cp', ['-a', src, dest])`
- Added `ALLOWED_SERVICES` whitelist — unknown service names rejected before any file/process ops
- Added `path.resolve` + boundary check to prevent path traversal via crafted service name

### `backup-sidecar/src/snapshot.ts`
- Same `restic()` fn fix
- `openssl rand` → `execFileSync('openssl', ['rand', '-hex', '32'])`
- `docker exec mysqldump` → `execFileSync('docker', ['exec', 'project-s-nextcloud-db', 'sh', '-c', HARDCODED_CMD])` — container name hardcoded, no user input
- `cp -a` → `execFileSync`
- Added `ALLOWED_SERVICES` whitelist + path boundary check

## Why execFileSync is safe

`execFileSync(binary, [arg1, arg2])` passes args as an array to the OS directly — no shell is spawned, so shell metacharacters (`;`, `|`, `$()`, backticks) in any argument are inert.

## Ref

Addresses C1 and C2 from security audit — ref #249 (does not close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)