### PR TITLE
fix(security): route dashboard Docker API through socket-proxy (ref #249)

### DIFF
--- a/Dashboard/Dashboard1/app/api/kiwix/restart/route.ts
+++ b/Dashboard/Dashboard1/app/api/kiwix/restart/route.ts
@@ -7,7 +7,8 @@ export async function POST() {
   return new Promise<NextResponse>((resolve) => {
     const req = http.request(
       {
-        socketPath: '/var/run/docker.sock',
+        host: 'socket-proxy',
+        port: 2375,
         path: '/containers/project-s-kiwix-reader/restart',
         method: 'POST',
       },

--- a/Dashboard/Dashboard1/custom-server.ts
+++ b/Dashboard/Dashboard1/custom-server.ts
@@ -33,11 +33,12 @@ const VALID_SHELL_TYPES = new Set(['ollama', 'container', null])
 const IDLE_TIMEOUT_MS = 30 * 60 * 1000
 
 
-/** Check if a named container is running via Docker socket. */
+/** Check if a named container is running via socket-proxy (TCP). */
 function isContainerRunning(name: string): Promise<boolean> {
   return new Promise((resolve) => {
     const req = httpGet({
-      socketPath: '/var/run/docker.sock',
+      host: 'socket-proxy',
+      port: 2375,
       path: `/containers/${name}/json`,
     }, (res) => {
       let data = ''

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,6 @@ services:
       - '3069:3069'
       - '3070:3070'
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
       - ./data:/data:ro
       - ./data/security:/app/data/security
       # Host metrics for Linux support (graceful degrade on macOS/Windows)
@@ -93,10 +92,12 @@ services:
       - PORT=3069
       - WS_PORT=3070
       - SECURITY_DIR=/app/data/security
+      - DOCKER_HOST=tcp://socket-proxy:2375
     restart: 'unless-stopped'
     depends_on:
       - jellyfin
       - nextcloud
+      - socket-proxy
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3069/').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
       interval: 30s


### PR DESCRIPTION
## What

Fixes H1 from security audit (ref #249) — dashboard was mounting raw `/var/run/docker.sock` despite ARCHITECTURE.md claiming socket-proxy isolation.

## Changes

### `docker-compose.yml`
- Removed `- /var/run/docker.sock:/var/run/docker.sock` from dashboard volumes
- Added `DOCKER_HOST=tcp://socket-proxy:2375` to dashboard environment
- Added `socket-proxy` to dashboard `depends_on`

### `Dashboard/Dashboard1/custom-server.ts`
- `isContainerRunning()`: `socketPath: '/var/run/docker.sock'` → `host: 'socket-proxy', port: 2375`

### `Dashboard/Dashboard1/app/api/kiwix/restart/route.ts`
- Same TCP change: `socketPath` → `host: 'socket-proxy', port: 2375`

### `app/api/stats/route.ts` (no change needed)
- Uses `docker` CLI (`execAsync('docker stats ...')`) — CLI respects `DOCKER_HOST` env var automatically ✅

## Why safe

socket-proxy (Tecnativa) already has `CONTAINERS=1` + `POST=1` — all dashboard operations (container inspect, restart, stats) are within scope. Traefik already uses the same `tcp://socket-proxy:2375` pattern.

## ARCHITECTURE.md

Previously aspirational ("dashboard accesses Docker via socket-proxy") — now accurate. No doc change needed.

## Ref

Addresses H1 from security audit — ref #249 (does not close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)