### PR TITLE
fix(security): drop container over-privileges — Collabora, OpenVPN, VPN creds (ref #249)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,7 +239,7 @@ services:
       - dictionaries=en_US
       - username=${COLLABORA_USERNAME}
       - password=${COLLABORA_PASSWORD}
-      - extra_params=--o:ssl.enable=false --o:ssl.termination=false
+      - extra_params=--o:ssl.enable=false --o:ssl.termination=false --o:security.capabilities=false
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9980/"]
       interval: 30s
@@ -247,11 +247,10 @@ services:
       retries: 3
       start_period: 30s
     logging: *default-logging
+    cap_drop:
+      - ALL
     cap_add:
       - MKNOD
-      - SYS_ADMIN
-    security_opt:
-      - seccomp=unconfined
     deploy:
       resources:
         limits:
@@ -569,9 +568,9 @@ services:
     container_name: project-s-openvpn
     networks:
       - backend
-    privileged: true
     cap_add:
       - NET_ADMIN
+      - NET_RAW
     ports:
       - '1194:1194/udp'
     volumes:
@@ -597,8 +596,8 @@ services:
     depends_on:
       - openvpn
     environment:
-      - OPENVPN_ADMIN_USERNAME=${VPN_ADMIN_USERNAME:-admin}
-      - OPENVPN_ADMIN_PASSWORD=${VPN_ADMIN_PASSWORD:-admin}
+      - OPENVPN_ADMIN_USERNAME=${VPN_ADMIN_USERNAME}
+      - OPENVPN_ADMIN_PASSWORD=${VPN_ADMIN_PASSWORD}
     volumes:
       - ./data/vpn:/etc/openvpn
       - ./data/vpn/db:/opt/openvpn-ui/db


### PR DESCRIPTION
## What

Fixes M1, M2, M5 from security audit (ref #249). Single file: `docker-compose.yml`.

## Changes

### M1: Collabora — drop `SYS_ADMIN` + `seccomp=unconfined`
- Added `cap_drop: [ALL]` — drops all implicit capabilities
- Removed `SYS_ADMIN` from `cap_add` — prevented via `--o:security.capabilities=false` flag added to `extra_params`, which disables Collabora's setuid sandbox (uses process isolation instead)
- Removed `security_opt: seccomp=unconfined` — default seccomp profile now active
- Kept `MKNOD` — still required by LibreOffice for device file operations

**Before:** `SYS_ADMIN` + `MKNOD` + `seccomp=unconfined` → near-full kernel access  
**After:** `MKNOD` only + default seccomp → minimal footprint

### M2: OpenVPN — remove `privileged: true`
- Removed `privileged: true` (gave ALL kernel capabilities)
- Added `NET_RAW` alongside existing `NET_ADMIN` — raw sockets needed for VPN tunnel

**Before:** all capabilities  
**After:** `NET_ADMIN` + `NET_RAW` only

### M5: VPN admin default `admin:admin` removed
- Removed `:-admin` fallback defaults from `OPENVPN_ADMIN_USERNAME` and `OPENVPN_ADMIN_PASSWORD`
- `.env.example` already has `VPN_ADMIN_PASSWORD=change_me_vpn_password` — users must set before first run

## Ref

Addresses M1, M2, M5 from security audit — ref #249 (does not close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)