### PR TITLE
fix(security): H4, M3, M4, M6 — auth, CORS, path traversal, matrix lock (ref #249)

### DIFF
--- a/Dashboard/Dashboard1/app/api/auth/setup/status/route.ts
+++ b/Dashboard/Dashboard1/app/api/auth/setup/status/route.ts
@@ -1,6 +1,16 @@
 import { NextResponse } from 'next/server'
 import { isSetupComplete } from '@/lib/db/users'
+import { getSession } from '@/lib/auth'
 
 export async function GET() {
+  // Allow unauthenticated access only before setup is complete —
+  // the setup wizard needs to check status before a session exists.
+  // Once setup is done, require a valid session to prevent enumeration.
+  if (isSetupComplete()) {
+    const session = await getSession()
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+  }
   return NextResponse.json({ complete: isSetupComplete() })
 }

--- a/agent/main.go
+++ b/agent/main.go
@@ -312,7 +312,7 @@ func handleMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	setCORSHeaders(w)
+	setCORSHeaders(w, r)
 
 	m, ok := metricsCache.get()
 	if !ok {
@@ -331,14 +331,18 @@ func handleMetrics(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {
-	setCORSHeaders(w)
+	setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, `{"status":"ok","platform":%q}`, runtime.GOOS)
 }
 
-func setCORSHeaders(w http.ResponseWriter) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "GET")
+func setCORSHeaders(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	// Allow only the dashboard origin — reject wildcard to prevent XSS-based metrics exfiltration
+	if origin == "http://localhost:3069" || origin == "http://127.0.0.1:3069" {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Methods", "GET")
+	}
 }
 
 // --- Helpers ---

--- a/backup-sidecar/src/index.ts
+++ b/backup-sidecar/src/index.ts
@@ -78,15 +78,21 @@ app.delete('/backups/:jobId', (req, res) => {
   
   if (!row) return res.status(404).json({ error: 'Backup not found' })
 
-  // Delete the physical file only if it exists and is valid
+  // Delete the physical file only if it exists, is valid, and within the backup directory
   if (row.archive_path && typeof row.archive_path === 'string' && row.archive_path.trim() !== '') {
-    const archivePath = path.join(process.env.SNAPSHOT_DIR || '/backups', row.archive_path)
-    try {
-      if (fs.existsSync(archivePath) && fs.lstatSync(archivePath).isFile()) {
-        fs.unlinkSync(archivePath)
+    const baseDir = path.resolve(process.env.SNAPSHOT_DIR || '/backups')
+    const archivePath = path.resolve(baseDir, row.archive_path)
+    // Boundary check — prevent path traversal via crafted archive_path in DB
+    if (!archivePath.startsWith(baseDir + path.sep)) {
+      console.warn(`Path traversal blocked for archive_path: ${row.archive_path}`)
+    } else {
+      try {
+        if (fs.existsSync(archivePath) && fs.lstatSync(archivePath).isFile()) {
+          fs.unlinkSync(archivePath)
+        }
+      } catch (e) {
+        console.warn(`Failed to delete file ${archivePath}: ${e}`)
       }
-    } catch (e) {
-      console.warn(`Failed to delete file ${archivePath}: ${e}`)
     }
   }
 

--- a/config/matrix/entrypoint.sh
+++ b/config/matrix/entrypoint.sh
@@ -10,16 +10,15 @@ python3 /etc/synapse-config/gen_config.py
 cp /etc/synapse-config/localhost.log.config /data/localhost.log.config
 
 if command -v update_synapse_database >/dev/null 2>&1; then
-    echo "[entrypoint] Applying Synapse database migrations — acquiring migration lock"
+    echo "[entrypoint] Applying Synapse database migrations — acquiring exclusive lock"
     mkdir -p "$(dirname "$MIGRATION_LOCK")"
-    touch "$MIGRATION_LOCK"
-    trap 'rm -f "$MIGRATION_LOCK"; echo "[entrypoint] migration lock released"' EXIT
     (
+        flock -x -n 9 || { echo "[entrypoint] Migration already running — skipping"; exit 0; }
+        touch "$MIGRATION_LOCK"
+        trap 'rm -f "$MIGRATION_LOCK"; echo "[entrypoint] migration lock released"' EXIT
         cd /data
         update_synapse_database --database-config /data/homeserver.yaml --run-background-updates
-    )
-    rm -f "$MIGRATION_LOCK"
-    trap - EXIT
+    ) 9>"${MIGRATION_LOCK}.lock"
 else
     echo "[entrypoint] update_synapse_database not found; Synapse will migrate on startup"
 fi


### PR DESCRIPTION
## What

Fixes H4, M3, M4, M6 from security audit (ref #249).

## Changes

### H4: Setup/status endpoint unauthenticated
**File:** `Dashboard/Dashboard1/app/api/auth/setup/status/route.ts`

- Pre-setup: endpoint remains open (wizard needs it before session exists)
- Post-setup: requires valid session — prevents LAN enumeration of initialized instances

### M3: Agent CORS wildcard → origin allowlist
**File:** `agent/main.go`

- `setCORSHeaders` now accepts `*http.Request` and checks `Origin` header
- Only `http://localhost:3069` and `http://127.0.0.1:3069` receive CORS headers
- Any other origin (including XSS-injected cross-origin requests) gets no CORS → browser blocks

### M4: Backup delete path traversal
**File:** `backup-sidecar/src/index.ts`

- Added `path.resolve` + `startsWith(baseDir + path.sep)` boundary check before `fs.unlinkSync`
- Crafted `archive_path` values (e.g. `../../etc/passwd`) are blocked and logged

### M6: Matrix migration — `touch` → `flock` exclusive lock
**File:** `config/matrix/entrypoint.sh`

- Replaced `touch` (non-exclusive) with `flock -x -n` on a `.lock` file
- Concurrent container restarts cannot both enter migration — second one exits cleanly with a log message

## Ref

Addresses H4, M3, M4, M6 from security audit — ref #249 (does not close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)