### PR TITLE
fix(auth): TOTP tokens → SQLite, WS ticket TTL 30s→5s + one-time use

### DIFF
--- a/Dashboard/Dashboard1/app/api/auth/login/route.ts
+++ b/Dashboard/Dashboard1/app/api/auth/login/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import { verifyUser, isSetupComplete } from '@/lib/db/users'
 import { sessionOptions, type SessionData } from '@/lib/session'
 import { checkRateLimit } from '@/lib/rate-limit'
+import { getDb } from '@/lib/db'
 
 const LoginSchema = z.object({
   username: z.string().min(1).max(64),
@@ -14,14 +15,8 @@ const LoginSchema = z.object({
 const LOGIN_LIMIT = { windowMs: 15 * 60 * 1000, max: 10 }
 
 export async function POST(req: NextRequest) {
-  // Clean up expired temp TOTP tokens
-  const tokenStore = globalThis as typeof globalThis & { _totpTokens?: Map<string, { expires: number }> }
-  if (tokenStore._totpTokens) {
-    const now = Date.now()
-    for (const [key, val] of tokenStore._totpTokens) {
-      if (val.expires < now) tokenStore._totpTokens.delete(key)
-    }
-  }
+  // Clean up expired temp TOTP tokens from SQLite
+  getDb().prepare('DELETE FROM totp_temp_tokens WHERE expires_at < ?').run(Date.now())
 
   if (!isSetupComplete()) {
     return NextResponse.json({ error: 'Setup not complete' }, { status: 403 })
@@ -68,14 +63,9 @@ export async function POST(req: NextRequest) {
       `${user.id}:${user.username}:${user.role}:${Date.now()}`
     ).toString('base64url')
 
-    const store = globalThis as typeof globalThis & { _totpTokens?: Map<string, { userId: number; username: string; role: string; expires: number }> }
-    if (!store._totpTokens) store._totpTokens = new Map()
-    store._totpTokens.set(tempToken, {
-      userId: user.id,
-      username: user.username,
-      role: user.role,
-      expires: Date.now() + 5 * 60 * 1000,
-    })
+    getDb().prepare(
+      'INSERT INTO totp_temp_tokens (token, user_id, username, role, expires_at) VALUES (?, ?, ?, ?, ?)'
+    ).run(tempToken, user.id, user.username, user.role, Date.now() + 5 * 60 * 1000)
 
     return NextResponse.json(
       { needsTotp: true, tempToken },

--- a/Dashboard/Dashboard1/app/api/auth/totp/verify/route.ts
+++ b/Dashboard/Dashboard1/app/api/auth/totp/verify/route.ts
@@ -23,15 +23,17 @@ export async function POST(req: NextRequest) {
 
   // Login mode with tempToken
   if (tempToken) {
-    const tokenStore = globalThis as typeof globalThis & { _totpTokens?: Map<string, { userId: number; username: string; role: string; expires: number }> }
-    const tokenData = tokenStore._totpTokens?.get(tempToken)
+    const db = getDb()
+    const tokenData = db.prepare(
+      'SELECT user_id, username, role, expires_at FROM totp_temp_tokens WHERE token = ?'
+    ).get(tempToken) as { user_id: number; username: string; role: string; expires_at: number } | undefined
 
-    if (!tokenData || tokenData.expires < Date.now()) {
-      tokenStore._totpTokens?.delete(tempToken)
+    if (!tokenData || tokenData.expires_at < Date.now()) {
+      db.prepare('DELETE FROM totp_temp_tokens WHERE token = ?').run(tempToken)
       return NextResponse.json({ error: 'Token expired' }, { status: 401 })
     }
 
-    const user = getUserById(tokenData.userId)
+    const user = getUserById(tokenData.user_id)
     if (!user || !user.totp_secret) {
       return NextResponse.json({ error: 'TOTP not configured' }, { status: 400 })
     }
@@ -41,12 +43,12 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Invalid code' }, { status: 401 })
     }
 
-    tokenStore._totpTokens?.delete(tempToken)
+    db.prepare('DELETE FROM totp_temp_tokens WHERE token = ?').run(tempToken)
 
     // Create session via cookie response
     const cookieRes = new NextResponse()
     const session = await getIronSession<SessionData>(req, cookieRes, sessionOptions)
-    session.userId = tokenData.userId
+    session.userId = tokenData.user_id
     session.username = tokenData.username
     session.role = tokenData.role as 'admin' | 'viewer'
     await session.save()

--- a/Dashboard/Dashboard1/custom-server.ts
+++ b/Dashboard/Dashboard1/custom-server.ts
@@ -57,10 +57,14 @@ function isContainerRunning(name: string): Promise<boolean> {
   })
 }
 
+// One-time use tracking for WS tickets — prevents replay within the TTL window
+const _usedTickets = new Set<string>()
+
 /**
  * Verify a WS auth ticket issued by GET /api/auth/ws-ticket.
  * Ticket format: "{timestamp_ms}.{hmac-sha256-hex}"
- * Returns true only when the HMAC is valid AND the ticket is within 30 seconds of issue.
+ * Returns true only when the HMAC is valid, the ticket is within 5 seconds of
+ * issue, and the ticket has not been used before (one-time use).
  */
 function verifyWsTicket(ticket: string | null): boolean {
   const secret = process.env.WS_SECRET
@@ -72,18 +76,30 @@ function verifyWsTicket(ticket: string | null): boolean {
   const ts  = ticket.slice(0, dot)
   const sig = ticket.slice(dot + 1)
 
-  // Reject tickets older than 30 seconds
+  // Reject tickets older than 5 seconds
   const timestamp = parseInt(ts, 10)
-  if (isNaN(timestamp) || Date.now() - timestamp > 30_000) return false
+  if (isNaN(timestamp) || Date.now() - timestamp > 5_000) return false
 
   // Constant-time HMAC comparison — prevents timing oracle attacks
   const expected = createHmac('sha256', secret).update(ts).digest('hex')
+  let valid: boolean
   try {
-    return timingSafeEqual(Buffer.from(sig, 'hex'), Buffer.from(expected, 'hex'))
+    valid = timingSafeEqual(Buffer.from(sig, 'hex'), Buffer.from(expected, 'hex'))
   } catch {
     // Buffer.from throws if sig is not valid hex or wrong length
     return false
   }
+
+  if (!valid) return false
+
+  // One-time use: reject replayed tickets
+  if (_usedTickets.has(ticket)) return false
+  _usedTickets.add(ticket)
+
+  // Auto-evict after TTL to bound memory growth
+  setTimeout(() => _usedTickets.delete(ticket), 5_000)
+
+  return true
 }
 
 const server = createServer((_req, res) => {

--- a/Dashboard/Dashboard1/lib/db/index.ts
+++ b/Dashboard/Dashboard1/lib/db/index.ts
@@ -56,6 +56,14 @@ export function getDb(): Database.Database {
     -- Run periodically via index check
 
     INSERT OR IGNORE INTO app_state(key, value) VALUES ('setup_complete', '0');
+
+    CREATE TABLE IF NOT EXISTS totp_temp_tokens (
+      token      TEXT    PRIMARY KEY,
+      user_id    INTEGER NOT NULL,
+      username   TEXT    NOT NULL,
+      role       TEXT    NOT NULL,
+      expires_at INTEGER NOT NULL
+    );
   `)
 
   // Add TOTP columns if they don't exist (idempotent)


### PR DESCRIPTION
## Summary

- **H2**: Replace `globalThis._totpTokens` in-memory Map with `totp_temp_tokens` SQLite table — tokens persist across restarts, no cross-worker leakage
- **H3**: WS auth ticket TTL reduced from 30s → 5s; added one-time use tracking via in-memory Set in `custom-server.ts` — replayed tickets rejected within window
- Schema migration is idempotent (`CREATE TABLE IF NOT EXISTS`)

## Files changed

- `lib/db/index.ts` — add `totp_temp_tokens` table to schema
- `app/api/auth/login/route.ts` — INSERT token to SQLite, cleanup via DELETE WHERE expires_at
- `app/api/auth/totp/verify/route.ts` — SELECT/DELETE from SQLite, fix field name `user_id`
- `custom-server.ts` — 30_000 → 5_000, add `_usedTickets` Set with auto-eviction

Ref #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)