### PR TITLE
fix(auth): save generated TOTP secret to user database during setup

### DIFF
--- a/Dashboard/Dashboard1/app/api/auth/totp/setup/route.ts
+++ b/Dashboard/Dashboard1/app/api/auth/totp/setup/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { requireSession } from '@/lib/auth'
 import { getUserById } from '@/lib/db/users'
 import { generateTotpSecret, generateTotpUri, generateQrDataUri } from '@/lib/totp'
+import { getDb } from '@/lib/db'
 
 export async function GET() {
   const session = await requireSession()
@@ -13,8 +14,13 @@ export async function GET() {
   }
 
   const secret = generateTotpSecret()
+  
+  // Save the generated secret to the database so it can be verified later
+  getDb().prepare('UPDATE users SET totp_secret = ? WHERE id = ?').run(secret, session.userId)
+
   const uri = generateTotpUri(secret, session.username)
   const qrDataUri = await generateQrDataUri(uri)
 
   return NextResponse.json({ enabled: false, secret, qrDataUri })
 }
+


### PR DESCRIPTION
Why:

During the initial user setup, the /api/auth/totp/setup endpoint was generating a new TOTP secret and sending the QR code to the frontend, but failing to persist that generated secret to the user's database row.

This resulted in a 'TOTP not configured' error when the user attempted to verify the 6-digit code, as the backend still saw a null secret in the database.

How:

Added an 'UPDATE users SET totp_secret = ? WHERE id = ?' database query to persist the newly generated secret before returning the QR code URI.