### PR TITLE
fix(nextcloud): use HOMEFORGE_LAN_IP for Collabora public_wopi_url

### DIFF
--- a/config/nextcloud/setup-office.sh
+++ b/config/nextcloud/setup-office.sh
@@ -42,9 +42,10 @@ php /var/www/html/occ config:app:set richdocuments wopi_callback_url \
 # IMPORTANT: this value is baked into Nextcloud's Content Security Policy on
 # every page load. If it is 'localhost', the browser will block Collabora from
 # loading on any device that is not the server itself.
-# For local Docker access, we use localhost:9980.
+# For local Docker access, we use the HOMEFORGE_LAN_IP variable.
+PUBLIC_WOPI_HOST="${HOMEFORGE_LAN_IP:-localhost}"
 php /var/www/html/occ config:app:set richdocuments public_wopi_url \
-    --value="http://localhost:9980" || true
+    --value="http://${PUBLIC_WOPI_HOST}:9980" || true
 
 # Trust Collabora hostname in Nextcloud
 php /var/www/html/occ config:system:set trusted_domains 3 \


### PR DESCRIPTION
Why:

The Nextcloud container entrypoint hook (setup-office.sh) was hardcoding public_wopi_url to localhost:9980 on every restart.

This overwrote the correct LAN IP that the install.sh script sets during initial deployment, causing 'Document loading failed' errors on Linux machines when accessing Nextcloud Office from other devices on the network.

How:

Updated the hook to read the HOMEFORGE_LAN_IP environment variable instead of hardcoding localhost.