### PR TITLE
feat(auth): add logout button to sidebar

### DIFF
--- a/Dashboard/Dashboard1/app/login/page.tsx
+++ b/Dashboard/Dashboard1/app/login/page.tsx
@@ -27,8 +27,12 @@ export default function LoginPage() {
 
   useEffect(() => {
     fetch('/api/auth/setup/status')
-      .then(r => r.json())
-      .then(data => { if (!data.complete) router.replace('/setup') })
+      .then(async r => {
+        // 401 = setup complete but unauthenticated — stay on /login
+        if (r.status === 401) return
+        const data = await r.json()
+        if (!data.complete) router.replace('/setup')
+      })
       .catch(() => {})
   }, [])
 

--- a/Dashboard/Dashboard1/components/dashboard/sidebar.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Activity,
   Database,
   Check,
+  LogOut,
   type LucideIcon,
 } from "lucide-react"
 import {
@@ -49,6 +50,11 @@ export function Sidebar({
   const [showThemes, setShowThemes] = useState(false)
   const [bouncingId, setBouncingId] = useState<string | null>(null)
   const { colorTheme, setColorTheme } = useTheme()
+
+  const handleLogout = async () => {
+    await fetch('/api/auth/logout', { method: 'POST' })
+    window.location.href = '/login'
+  }
 
   // Trigger bounce animation on dock click
   const handleBounceClick = (id: string) => {
@@ -191,7 +197,7 @@ export function Sidebar({
           </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
-              <button 
+              <button
                 onClick={() => setShowSettings(!showSettings)}
                 className={cn(
                   "flex h-9 w-9 items-center justify-center rounded-xl transition-all"
@@ -210,6 +216,22 @@ export function Sidebar({
               <p>Settings</p>
             </TooltipContent>
           </Tooltip>
+          {!IS_LANDING && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={handleLogout}
+                  className="flex h-9 w-9 items-center justify-center rounded-xl transition-all hover:bg-red-500/10"
+                  style={{ color: colorTheme.muted }}
+                >
+                  <LogOut className="h-[18px] w-[18px]" strokeWidth={1.5} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right" sideOffset={12}>
+                <p>Logout</p>
+              </TooltipContent>
+            </Tooltip>
+          )}
         </div>
 
         {/* Settings Popup */}

--- a/Project_S_Logs/00_Master_Implementation_Plan.md
+++ b/Project_S_Logs/00_Master_Implementation_Plan.md
@@ -18,6 +18,7 @@
 | Architecture SSOT | ✅ Merged | #241 | `docs/architecture-ssot-241` | #56 |
 | Network Segmentation | ✅ Merged | #242 | `feat/network-segmentation-242` | #57 |
 | Host Agent Auto-Start | ⏳ PR Open | #245 | `feat/host-agent-autostart-245` | #58 |
+| Logout Functionality  | ⏳ PR Open | #262 | `feat/logout-262`              | #59 |
 
 ### v1.0 Features Shipped
 

--- a/Project_S_Logs/59_Logout.md
+++ b/Project_S_Logs/59_Logout.md
@@ -1,0 +1,49 @@
+# 59 — Logout Functionality (Issue #262)
+
+**Date:** April 18, 2026
+**Issue:** `#262`
+**Branch:** `feat/logout-262`
+**PR:** `#264`
+**Status:** ⏳ PR Open
+
+---
+
+## Problem
+
+No logout button existed in the dashboard. Users had no way to end their session without manually clearing cookies. Raised by Saad as both a missing feature and a security risk.
+
+---
+
+## Root Cause (Login Redirect Bug)
+
+A secondary bug was discovered during implementation: after logout, the app redirected users to `/setup` instead of staying on `/login`.
+
+**Cause:** `GET /api/auth/setup/status` returns `401` (not `{ complete: false }`) when setup is done but no session exists. The login page `useEffect` checked `if (!data.complete)` — since `401` response body is `{ error: 'Unauthorized' }`, `data.complete` was `undefined`, which is falsy, triggering the `/setup` redirect.
+
+---
+
+## What Was Implemented
+
+### Backend
+`app/api/auth/logout/route.ts` — already existed. `POST` handler calls `session.destroy()` which clears the iron-session cookie.
+
+### Frontend
+**`components/dashboard/sidebar.tsx`:**
+- Added `LogOut` icon (lucide-react)
+- Added `handleLogout` async fn: `POST /api/auth/logout` → `window.location.href = '/login'`
+- Added logout button below Settings in sidebar bottom section
+- Hidden in landing/preview mode (`NEXT_PUBLIC_LANDING_MODE=true`)
+
+**`app/login/page.tsx`:**
+- Fixed `useEffect` to check HTTP status before parsing body
+- `401` → stay on `/login` (setup complete, just unauthenticated)
+- `200` with `complete: false` → redirect to `/setup`
+
+---
+
+## Files Changed
+
+- `Dashboard/Dashboard1/components/dashboard/sidebar.tsx` (logout button)
+- `Dashboard/Dashboard1/app/login/page.tsx` (setup redirect bug fix)
+- `Project_S_Logs/59_Logout.md` (this file)
+- `Project_S_Logs/00_Master_Implementation_Plan.md` (roadmap updated)


### PR DESCRIPTION
## Summary

- Adds `LogOut` icon button at the bottom of the sidebar (below Settings)
- On click: `POST /api/auth/logout` → destroys iron-session cookie → redirects to `/login`
- Hidden in landing/preview mode (`NEXT_PUBLIC_LANDING_MODE=true`)
- Backend logout route (`/api/auth/logout`) already existed and is unchanged

Closes #262

## Test plan

- [x] Login, click logout button in sidebar — session cleared, redirected to `/login`
- [x] Attempting to navigate back to `/` after logout redirects to `/login`
- [ ] Logout button absent in landing mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)