### PR TITLE
fix(security): harden TOTP auth — random token, rate limit, cookie strict

### DIFF
--- a/Dashboard/Dashboard1/app/api/auth/login/route.ts
+++ b/Dashboard/Dashboard1/app/api/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getIronSession } from 'iron-session'
+import { randomBytes } from 'crypto'
 import { z } from 'zod'
 import { verifyUser, isSetupComplete } from '@/lib/db/users'
 import { sessionOptions, type SessionData } from '@/lib/session'
@@ -59,9 +60,7 @@ export async function POST(req: NextRequest) {
 
   // If user has TOTP enabled, require second factor before creating session
   if (user.totp_enabled) {
-    const tempToken = Buffer.from(
-      `${user.id}:${user.username}:${user.role}:${Date.now()}`
-    ).toString('base64url')
+    const tempToken = randomBytes(32).toString('hex')
 
     getDb().prepare(
       'INSERT INTO totp_temp_tokens (token, user_id, username, role, expires_at) VALUES (?, ?, ?, ?, ?)'

--- a/Dashboard/Dashboard1/app/api/auth/totp/setup/route.ts
+++ b/Dashboard/Dashboard1/app/api/auth/totp/setup/route.ts
@@ -13,10 +13,12 @@ export async function GET() {
     return NextResponse.json({ enabled: true })
   }
 
-  const secret = generateTotpSecret()
-  
-  // Save the generated secret to the database so it can be verified later
-  getDb().prepare('UPDATE users SET totp_secret = ? WHERE id = ?').run(secret, session.userId)
+  // Reuse any pending (unconfirmed) secret — avoids rotating mid-setup if the
+  // endpoint is called more than once before the user scans the QR code.
+  const secret = user.totp_secret ?? generateTotpSecret()
+  if (!user.totp_secret) {
+    getDb().prepare('UPDATE users SET totp_secret = ? WHERE id = ?').run(secret, session.userId)
+  }
 
   const uri = generateTotpUri(secret, session.username)
   const qrDataUri = await generateQrDataUri(uri)

--- a/Dashboard/Dashboard1/app/api/auth/totp/verify/route.ts
+++ b/Dashboard/Dashboard1/app/api/auth/totp/verify/route.ts
@@ -6,6 +6,10 @@ import { verifyTotpCode } from '@/lib/totp'
 import { getDb } from '@/lib/db'
 import { getIronSession } from 'iron-session'
 import { sessionOptions, type SessionData } from '@/lib/session'
+import { checkRateLimit } from '@/lib/rate-limit'
+
+// 5 attempts per temp token per 15-minute window — prevents TOTP brute-force
+const TOTP_LIMIT = { windowMs: 15 * 60 * 1000, max: 5 }
 
 const TotpSchema = z.object({
   code: z.string().length(6).regex(/^\d{6}$/),
@@ -23,6 +27,15 @@ export async function POST(req: NextRequest) {
 
   // Login mode with tempToken
   if (tempToken) {
+    // Rate-limit by temp token — prevents brute-forcing the 6-digit TOTP code
+    const rl = checkRateLimit(`totp:${tempToken}`, TOTP_LIMIT)
+    if (!rl.allowed) {
+      return NextResponse.json(
+        { error: 'Too many attempts. Please log in again.' },
+        { status: 429 }
+      )
+    }
+
     const db = getDb()
     const tokenData = db.prepare(
       'SELECT user_id, username, role, expires_at FROM totp_temp_tokens WHERE token = ?'

--- a/Dashboard/Dashboard1/app/api/auth/ws-ticket/route.ts
+++ b/Dashboard/Dashboard1/app/api/auth/ws-ticket/route.ts
@@ -17,6 +17,6 @@ export async function GET() {
     .update(ts)
     .digest('hex')
 
-  // Ticket format: "{timestamp}.{hmac-hex}" — 30 second TTL enforced by the WS server
+  // Ticket format: "{timestamp}.{hmac-hex}" — 5 second TTL enforced by the WS server
   return NextResponse.json({ ticket: `${ts}.${sig}` })
 }

--- a/Dashboard/Dashboard1/lib/session.ts
+++ b/Dashboard/Dashboard1/lib/session.ts
@@ -19,10 +19,9 @@
 import type { SessionOptions } from 'iron-session'
 
 export interface SessionData {
-  userId:       number
-  username:     string
-  role:         'admin' | 'viewer'
-  totpVerified?: boolean
+  userId:   number
+  username: string
+  role:     'admin' | 'viewer'
 }
 
 /**
@@ -47,6 +46,6 @@ export const sessionOptions: SessionOptions = {
     httpOnly: true,
     // Only enforce secure in production; allows local dev over http
     secure:   process.env.NODE_ENV === 'production',
-    sameSite: 'lax' as const,
+    sameSite: 'strict' as const,
   },
 }

--- a/Project_S_Logs/00_Master_Implementation_Plan.md
+++ b/Project_S_Logs/00_Master_Implementation_Plan.md
@@ -19,6 +19,7 @@
 | Network Segmentation | ✅ Merged | #242 | `feat/network-segmentation-242` | #57 |
 | Host Agent Auto-Start | ⏳ PR Open | #245 | `feat/host-agent-autostart-245` | #58 |
 | Logout Functionality  | ⏳ PR Open | #262 | `feat/logout-262`              | #59 |
+| Auth Security Hardening | ⏳ PR Open | #265 | `fix/totp-auth-security-265` | #60 |
 
 ### v1.0 Features Shipped
 

--- a/Project_S_Logs/60_Auth_Security_Hardening.md
+++ b/Project_S_Logs/60_Auth_Security_Hardening.md
@@ -1,0 +1,110 @@
+# 60 — Auth Security Hardening (Issue #265)
+
+**Date:** April 18, 2026
+**Issue:** `#265`
+**Branch:** `fix/totp-auth-security-265`
+**PR:** `#266`
+**Status:** ⏳ PR Open
+
+---
+
+## Background
+
+Post-merge audit of the login/logout system (added in PR #264) revealed two HIGH severity vulnerabilities in the TOTP authentication flow, plus several lower-severity issues. All fixed in this PR.
+
+---
+
+## Vulnerabilities Fixed
+
+### 🔴 HIGH — Predictable TOTP Temp Token
+
+**File:** `app/api/auth/login/route.ts`
+
+The temp token issued during TOTP login was:
+```
+base64url(userId + ":" + username + ":" + role + ":" + Date.now())
+```
+
+This is not random. Admin is always `userId=1`, username is known from the login interaction, role is one of two values, and the timestamp window is 5 minutes (~300,000 possible values). An attacker who logged in as their own account could reverse-engineer the format and forge a token for any user — including admin.
+
+**Fix:** Replaced with `crypto.randomBytes(32).toString('hex')` — 256 bits of entropy, unguessable.
+
+---
+
+### 🔴 HIGH — No Rate Limit on TOTP Verify
+
+**File:** `app/api/auth/totp/verify/route.ts`
+
+`POST /api/auth/totp/verify` had no throttling. TOTP codes are 6 digits = 1,000,000 combinations. With a valid or forged temp token, an attacker could brute-force the TOTP code in seconds with no resistance.
+
+**Fix:** Added `checkRateLimit` keyed on the temp token — max 5 attempts per 15-minute window. On the 6th attempt the endpoint returns 429 and instructs the user to log in again.
+
+---
+
+### 🟠 MEDIUM — TOTP Setup Secret Rotated on Every GET
+
+**File:** `app/api/auth/totp/setup/route.ts`
+
+Every call to `GET /api/auth/totp/setup` for a user with TOTP not yet enabled generated a fresh secret and overwrote the one in the DB. If the endpoint was hit more than once mid-setup (browser refresh, race condition, or CSRF), the secret would rotate and the QR code already scanned by the user would become invalid.
+
+**Fix:** Now checks if a pending secret already exists (`user.totp_secret` is non-null but `totp_enabled=0`) and reuses it. A new secret is only generated when the field is truly empty.
+
+---
+
+### 🟡 LOW — `sameSite: 'lax'` → `'strict'`
+
+**File:** `lib/session.ts`
+
+The session cookie used `sameSite: 'lax'`, which allows the cookie to be sent on top-level cross-site navigations. Changed to `strict` — the cookie is now only sent on same-origin requests. No functional impact for normal usage.
+
+---
+
+### 🟡 LOW — Unused `totpVerified` Field in SessionData
+
+**File:** `lib/session.ts`
+
+`SessionData` contained a `totpVerified?: boolean` field that was never set or checked anywhere in the codebase. Removed to avoid future confusion — a developer might assume TOTP state is tracked per-session and write logic based on it, creating a false trust boundary.
+
+---
+
+### 🟡 LOW — Stale Comment in WS Ticket Route
+
+**File:** `app/api/auth/ws-ticket/route.ts`
+
+Comment said "30 second TTL" — the actual TTL was changed to 5 seconds in PR #254. Comment updated.
+
+---
+
+## Honest Self-Assessment (Ethical Hacker Perspective)
+
+**Grade: C+ for the original work. B+ for the audit.**
+
+What was missed and shouldn't have been:
+
+- **The temp token issue is embarrassing.** Base64 encoding is not encryption or hashing. Using predictable data as a security token is a textbook mistake. This should have been caught during initial implementation of the TOTP flow, not discovered in a post-merge audit. A random token takes one line — there's no excuse for the original approach.
+
+- **Forgetting rate limits on a second auth factor is a significant oversight.** The main login endpoint has rate limiting. The TOTP verify endpoint is the continuation of the same auth flow. The same threat model applies. This was an inconsistency that an attacker would find immediately.
+
+- **The TOTP setup secret rotation issue is subtler** and more forgivable — it requires a specific sequence to exploit. Still, it's the kind of thing a code reviewer should catch.
+
+What was done well:
+
+- The rate limiter implementation itself is solid (sliding window, username-keyed on main login).
+- Argon2id with proper memory/time parameters is correct.
+- iron-session with HKDF-derived key is a solid choice.
+- SQLite-backed temp tokens (encrypted at rest via SQLCipher) are appropriate — better than the in-memory Map they replaced.
+- The WS ticket system (HMAC + 5s TTL + one-time use) is well-designed.
+
+The two HIGH issues together form a complete attack chain: forge the predictable token → brute-force TOTP with no rate limit → gain admin session. This is a real, exploitable vulnerability that existed in production between PR #264 merge and PR #266 merge.
+
+---
+
+## Files Changed
+
+- `Dashboard/Dashboard1/app/api/auth/login/route.ts` (random token)
+- `Dashboard/Dashboard1/app/api/auth/totp/verify/route.ts` (rate limit)
+- `Dashboard/Dashboard1/app/api/auth/totp/setup/route.ts` (reuse secret)
+- `Dashboard/Dashboard1/lib/session.ts` (sameSite strict, remove totpVerified)
+- `Dashboard/Dashboard1/app/api/auth/ws-ticket/route.ts` (fix comment)
+- `Project_S_Logs/60_Auth_Security_Hardening.md` (this file)
+- `Project_S_Logs/00_Master_Implementation_Plan.md` (roadmap updated)

--- a/SECURITY_CHECKLIST.md
+++ b/SECURITY_CHECKLIST.md
@@ -1,0 +1,45 @@
+# Security Checklist for Auth & API PRs
+
+Run this before opening any PR that touches authentication, session handling, or API endpoints.
+
+---
+
+## Tokens & Secrets
+
+- [ ] Any token that grants access uses `crypto.randomBytes(32).toString('hex')` — never base64 of known data, never UUIDs, never timestamps
+- [ ] Tokens are stored in the DB (not in-memory) if they need to survive restarts
+- [ ] Tokens have an expiry and are deleted after use or on expiry
+
+## Rate Limiting
+
+- [ ] Every endpoint that accepts credentials or auth tokens has `checkRateLimit` applied
+- [ ] If step 1 of an auth flow has a rate limit, step 2 has one too
+- [ ] Rate limit key is specific enough — keyed on token, username, or user ID (not just IP)
+
+## Input Validation
+
+- [ ] All inputs validated with Zod before use
+- [ ] String lengths bounded
+- [ ] No user input interpolated into SQL (use prepared statements only)
+
+## Session & Cookies
+
+- [ ] Session cookie is `httpOnly: true`, `sameSite: 'strict'`, `secure: true` in production
+- [ ] `session.destroy()` called on logout
+- [ ] No sensitive data stored in the session beyond what's needed (userId, username, role)
+
+## Auth Guards
+
+- [ ] Protected routes call `requireSession()` or `requireAdmin()`
+- [ ] New public routes are explicitly added to `PUBLIC_PREFIXES` in `middleware.ts` — not just assumed to be accessible
+
+## General
+
+- [ ] No `console.log` of passwords, tokens, or secrets
+- [ ] Error messages don't leak whether a username exists or not
+- [ ] New endpoint has a threat model: who can call it, with what, how many times
+
+---
+
+> Added after the TOTP auth vulnerabilities found post-merge in April 2026 (issues #262, #265).
+> These checks exist because basics were missed in production — use this every time.


### PR DESCRIPTION
Fixes #265. Two HIGH + three LOW severity issues from the auth security audit.

## Changes

**🔴 HIGH — Predictable TOTP temp token** (`login/route.ts`)
Was base64 of `userId:username:role:timestamp` — guessable. Now `crypto.randomBytes(32).toString('hex')`.

**🔴 HIGH — No rate limit on TOTP verify** (`totp/verify/route.ts`)
Added `checkRateLimit` keyed on the temp token — 5 attempts per 15 min. Brute-forcing 1M TOTP codes is now blocked.

**🟠 MEDIUM — TOTP setup rotates secret on every GET** (`totp/setup/route.ts`)
Now reuses any existing pending (unconfirmed) secret. Only generates a new one if `totp_secret IS NULL`.

**🟡 LOW — `sameSite: 'lax'` → `'strict'`** (`session.ts`)
Tighter CSRF protection. No functional impact for normal users.

**🟡 LOW — Remove unused `totpVerified` field** (`session.ts`)
Dead code that could mislead future developers into thinking TOTP state is tracked per-session.

**🟡 LOW — Fix stale comment** (`ws-ticket/route.ts`)
Comment said "30 second TTL" — actual TTL is 5s since the last security PR.

## Test plan

- [ ] Login with TOTP enabled — flow works end to end
- [ ] Enter wrong TOTP code 5 times — 6th attempt returns 429
- [ ] Token in 429 response is expired/deleted — retrying with same token fails
- [ ] Open TOTP setup page twice — same QR code shown both times (secret not rotated)
- [ ] Logout and re-login — session cookie functions correctly with sameSite=strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)