### PR TITLE
feat(home): refine metrics/backups snap flow

### DIFF
--- a/Dashboard/Dashboard1/app/page.tsx
+++ b/Dashboard/Dashboard1/app/page.tsx
@@ -26,6 +26,7 @@ interface ActiveWindow {
 }
 
 export default function HomePage() {
+  const HOME_SECTION_COUNT = 3
   const IS_LANDING = process.env.NEXT_PUBLIC_LANDING_MODE === 'true'
   const { colorTheme } = useTheme()
   const [scrollProgress, setScrollProgress] = useState(0)
@@ -35,7 +36,17 @@ export default function HomePage() {
   const [currentSection, setCurrentSection] = useState("home")
   const [openWindows, setOpenWindows] = useState<ActiveWindow[]>([])
   const containerRef = useRef<HTMLDivElement>(null)
+  const metricsScrollRef = useRef<HTMLDivElement>(null)
+  const backupsScrollRef = useRef<HTMLDivElement>(null)
+  const snapLockRef = useRef(false)
+  const snapTargetRef = useRef<number | null>(null)
+  const boundaryConfirmRef = useRef<{ sectionIdx: number; dir: number; expiresAt: number } | null>(null)
+  const lastWheelAtRef = useRef(0)
+  const postSnapCooldownRef = useRef(0)
+  const snapRafRef = useRef<number | null>(null)
+  const snapTimeoutRef = useRef<number | null>(null)
   const homeMetricsThreshold = 0.55
+  const homeBackupsThreshold = 1.55
 
   // Mock data for Landing Page
   const MOCK_STATS = IS_LANDING ? {
@@ -74,17 +85,183 @@ export default function HomePage() {
   }, [])
 
   useEffect(() => {
+    if (currentSection === "home") {
+      document.documentElement.classList.add("home-snap")
+    } else {
+      document.documentElement.classList.remove("home-snap")
+    }
+    return () => document.documentElement.classList.remove("home-snap")
+  }, [currentSection])
+
+  const clearSnapTimers = useCallback(() => {
+    if (snapRafRef.current !== null) {
+      cancelAnimationFrame(snapRafRef.current)
+      snapRafRef.current = null
+    }
+    if (snapTimeoutRef.current !== null) {
+      window.clearTimeout(snapTimeoutRef.current)
+      snapTimeoutRef.current = null
+    }
+  }, [])
+
+  const clampHomeSectionIndex = useCallback((index: number) => {
+    return Math.max(0, Math.min(HOME_SECTION_COUNT - 1, index))
+  }, [HOME_SECTION_COUNT])
+
+  const getHomeSectionIndex = useCallback((scrollY: number) => {
+    const vh = Math.max(window.innerHeight, 1)
+    return clampHomeSectionIndex(Math.round(scrollY / vh))
+  }, [clampHomeSectionIndex])
+
+  const getHomeInnerScroller = useCallback((sectionIdx: number) => {
+    if (sectionIdx === 1) return metricsScrollRef.current
+    if (sectionIdx === 2) return backupsScrollRef.current
+    return null
+  }, [])
+
+  const canScrollInnerSection = useCallback((el: HTMLDivElement, dir: number) => {
+    const atTop = el.scrollTop <= 0
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1
+    return (dir > 0 && !atBottom) || (dir < 0 && !atTop)
+  }, [])
+
+  const isAtInnerBoundary = useCallback((el: HTMLDivElement, dir: number) => {
+    const atTop = el.scrollTop <= 0
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1
+    return dir > 0 ? atBottom : atTop
+  }, [])
+
+  const releaseHomeSnapLock = useCallback((targetIdx?: number) => {
+    if (targetIdx !== undefined) {
+      snapTargetRef.current = targetIdx
+    }
+    postSnapCooldownRef.current = Date.now() + 220
+    snapLockRef.current = false
+    document.documentElement.classList.add("home-snap")
+    clearSnapTimers()
+  }, [clearSnapTimers])
+
+  const settleHomeSnap = useCallback((targetIdx: number) => {
+    clearSnapTimers()
+
+    const checkSettled = () => {
+      const targetY = targetIdx * window.innerHeight
+      if (Math.abs(window.scrollY - targetY) <= 2) {
+        releaseHomeSnapLock(targetIdx)
+        return
+      }
+      snapRafRef.current = requestAnimationFrame(checkSettled)
+    }
+
+    snapRafRef.current = requestAnimationFrame(checkSettled)
+    snapTimeoutRef.current = window.setTimeout(() => {
+      window.scrollTo({ top: targetIdx * window.innerHeight, behavior: "smooth" })
+      releaseHomeSnapLock(targetIdx)
+    }, 1200)
+  }, [clearSnapTimers, releaseHomeSnapLock])
+
+  // Wheel-throttled section snap: enforces one-section-per-gesture on home,
+  // lets inner scrollers consume wheel until they hit boundary.
+  useEffect(() => {
+    if (currentSection !== "home") return
+
+    const onWheel = (e: WheelEvent) => {
+      if (Math.abs(e.deltaY) < 4) return
+      const dir = e.deltaY > 0 ? 1 : -1
+      const now = Date.now()
+      const isFreshGesture = now - lastWheelAtRef.current > 180
+      lastWheelAtRef.current = now
+
+      if (snapLockRef.current) {
+        e.preventDefault()
+        return
+      }
+
+      if (postSnapCooldownRef.current > now) {
+        postSnapCooldownRef.current = now + 220
+        e.preventDefault()
+        return
+      }
+
+      const currentIdx = snapTargetRef.current ?? getHomeSectionIndex(window.scrollY)
+      const innerScroller = getHomeInnerScroller(currentIdx)
+      const isInnerScrollTarget = innerScroller?.contains(e.target as Node) ?? false
+
+      if (innerScroller && canScrollInnerSection(innerScroller, dir)) {
+        boundaryConfirmRef.current = null
+        if (isInnerScrollTarget) {
+          return
+        }
+        e.preventDefault()
+        return
+      }
+
+      if (innerScroller && isAtInnerBoundary(innerScroller, dir)) {
+        const pending = boundaryConfirmRef.current
+        const needsConfirm = !pending
+          || pending.sectionIdx !== currentIdx
+          || pending.dir !== dir
+          || pending.expiresAt < now
+
+        if (needsConfirm || !isFreshGesture) {
+          boundaryConfirmRef.current = {
+            sectionIdx: currentIdx,
+            dir,
+            expiresAt: now + 2000,
+          }
+          e.preventDefault()
+          return
+        }
+      } else {
+        boundaryConfirmRef.current = null
+      }
+
+      const targetIdx = clampHomeSectionIndex(currentIdx + dir)
+      if (targetIdx === currentIdx) {
+        snapTargetRef.current = currentIdx
+        boundaryConfirmRef.current = null
+        return
+      }
+
+      e.preventDefault()
+      boundaryConfirmRef.current = null
+      snapLockRef.current = true
+      snapTargetRef.current = targetIdx
+      // Drop snap-type during programmatic scroll so mandatory snap doesn't hijack mid-transit
+      document.documentElement.classList.remove("home-snap")
+      window.scrollTo({ top: targetIdx * window.innerHeight, behavior: "smooth" })
+      settleHomeSnap(targetIdx)
+    }
+
+    window.addEventListener("wheel", onWheel, { passive: false })
+    return () => {
+      window.removeEventListener("wheel", onWheel)
+      clearSnapTimers()
+      boundaryConfirmRef.current = null
+      snapLockRef.current = false
+    }
+  }, [canScrollInnerSection, clampHomeSectionIndex, clearSnapTimers, currentSection, getHomeInnerScroller, getHomeSectionIndex, isAtInnerBoundary, settleHomeSnap])
+
+  useEffect(() => {
     const handleScroll = () => {
       if (!containerRef.current || currentSection !== "home") return
       const scrollTop = window.scrollY
       const windowHeight = window.innerHeight
-      const progress = Math.min(scrollTop / windowHeight, 1)
+      const progress = Math.min(scrollTop / windowHeight, 2)
       setScrollProgress(progress)
+
+      if (!snapLockRef.current) {
+        snapTargetRef.current = getHomeSectionIndex(scrollTop)
+      }
+
+      if (boundaryConfirmRef.current && boundaryConfirmRef.current.expiresAt < Date.now()) {
+        boundaryConfirmRef.current = null
+      }
     }
 
     window.addEventListener("scroll", handleScroll, { passive: true })
     return () => window.removeEventListener("scroll", handleScroll)
-  }, [currentSection])
+  }, [currentSection, getHomeSectionIndex])
 
   const bringToFront = useCallback((id: string) => {
     setOpenWindows(prev => {
@@ -152,8 +329,12 @@ export default function HomePage() {
   const bgColor = mounted ? colorTheme.background : "#0a0a0a"
   const accentColor = mounted ? colorTheme.accent : "#d4e157"
   const highlightedSection =
-    currentSection === "home" && scrollProgress >= homeMetricsThreshold
-      ? "metrics"
+    currentSection === "home"
+      ? scrollProgress >= homeBackupsThreshold
+        ? "backups"
+        : scrollProgress >= homeMetricsThreshold
+          ? "metrics"
+          : currentSection
       : currentSection
 
   const handleNavigate = (section: string) => {
@@ -169,7 +350,12 @@ export default function HomePage() {
     if (section === "home") {
       setOpenWindows(prev => prev.map(w => w.isClosing ? w : { ...w, isMinimized: true }))
       setCurrentSection(section)
-      window.scrollTo({ top: 0, behavior: "smooth" })
+      // Snap-mandatory can hijack smooth scroll → use instant scroll.
+      // Double-call (now + rAF) handles layout/height change between current and home container.
+      window.scrollTo({ top: 0, behavior: "auto" })
+      requestAnimationFrame(() => {
+        window.scrollTo({ top: 0, behavior: "auto" })
+      })
       return
     }
     // Minimize open windows when navigating to metrics
@@ -190,7 +376,7 @@ export default function HomePage() {
   return (
     <div 
       ref={containerRef}
-      className={currentSection === "home" ? "relative min-h-[200vh]" : "relative h-screen overflow-hidden"}
+      className={currentSection === "home" ? "relative min-h-[300vh]" : "relative h-screen overflow-hidden"}
       style={{ backgroundColor: bgColor }}
     >
       {/* Landing Page Banner */}
@@ -329,18 +515,36 @@ export default function HomePage() {
                   transition: "opacity 0.1s ease-out, transform 0.1s ease-out",
                   pointerEvents: openWindows.some(w => !w.isMinimized && !w.isClosing) ? 'none' : 'auto',
                   position: openWindows.length > 0 ? 'relative' : 'relative',
+                  minHeight: "100vh",
+                  scrollSnapAlign: "start",
+                  scrollSnapStop: "always",
                 }}
               >
                 <WelcomeSection onNavigate={handleNavigate} />
               </div>
               <div
                 style={{
-                  opacity: scrollProgress > 0.3 ? (scrollProgress - 0.3) / 0.7 : 0,
+                  opacity: Math.max(0, Math.min(1, (scrollProgress - 0.3) / 0.7, (1.8 - scrollProgress) / 0.5)),
                   transform: `translateY(${(1 - scrollProgress) * 30}px)`,
                   transition: "opacity 0.1s ease-out, transform 0.1s ease-out",
+                  minHeight: "100vh",
+                  scrollSnapAlign: "start",
+                  scrollSnapStop: "always",
                 }}
               >
-                <MetricsSection landingData={MOCK_STATS as any} />
+                <MetricsSection landingData={MOCK_STATS as any} scrollContainerRef={metricsScrollRef} showScrollCue />
+              </div>
+              <div
+                style={{
+                  opacity: Math.max(0, Math.min(1, (scrollProgress - 1.3) / 0.7)),
+                  transform: `translateY(${(2 - scrollProgress) * 30}px)`,
+                  transition: "opacity 0.1s ease-out, transform 0.1s ease-out",
+                  minHeight: "100vh",
+                  scrollSnapAlign: "start",
+                  scrollSnapStop: "always",
+                }}
+              >
+                <BackupSection isLanding={IS_LANDING} scrollContainerRef={backupsScrollRef} />
               </div>
             </>
           )}
@@ -387,6 +591,10 @@ export default function HomePage() {
         
         html {
           scroll-behavior: smooth;
+        }
+
+        html.home-snap {
+          scroll-snap-type: y mandatory;
         }
         
         /* Custom scrollbar */

--- a/Dashboard/Dashboard1/components/dashboard/backup-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/backup-section.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState, useRef, useCallback } from "react"
+import { useEffect, useState, useRef, useCallback, type RefObject } from "react"
 import { Plus, RotateCcw, ShieldCheck, Database, Clock, FileJson, CheckCircle2, AlertCircle, Loader2, HardDrive, X } from "lucide-react"
 import { Skeleton } from "@/components/ui/skeleton"
 
@@ -31,7 +31,13 @@ function SectionHeader({ title, action }: { title: string; action?: React.ReactN
   )
 }
 
-export function BackupSection({ isLanding }: { isLanding?: boolean }) {
+export function BackupSection({
+  isLanding,
+  scrollContainerRef,
+}: {
+  isLanding?: boolean
+  scrollContainerRef?: RefObject<HTMLDivElement | null>
+}) {
   const [backups, setBackups] = useState<BackupEntry[]>([])
   const [restoreLogs, setRestoreLogs] = useState<RestoreLogEntry[]>([])
   const [backingUp, setBackingUp] = useState(false)
@@ -260,7 +266,7 @@ export function BackupSection({ isLanding }: { isLanding?: boolean }) {
       </div>
 
       {/* Main content */}
-      <div className="flex-1 overflow-y-auto px-3 sm:px-6 py-3 space-y-4">
+      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto px-3 sm:px-6 py-3 space-y-4">
 
         {/* Stat pills row */}
         <div className="flex flex-wrap items-center gap-x-6 gap-y-2">

--- a/Dashboard/Dashboard1/components/dashboard/metrics-section.tsx
+++ b/Dashboard/Dashboard1/components/dashboard/metrics-section.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState, useRef, useCallback } from "react"
+import { useEffect, useState, useRef, useCallback, type RefObject } from "react"
 import { Activity, ChevronDown, ArrowUpRight, ArrowDownRight, MoreHorizontal, Plus, Download, RotateCcw, ServerOff, ChevronRight } from "lucide-react"
 import { Area, AreaChart, XAxis, YAxis, ResponsiveContainer, Tooltip, CartesianGrid, Line, LineChart } from "recharts"
 
@@ -56,6 +56,34 @@ interface HistoryPoint {
 }
 
 type TimeRange = "1h" | "6h" | "24h" | "7d"
+
+const EMPTY_STATS: StatsData = {
+  cpu: "0",
+  memPerc: "0",
+  memBytes: "0",
+  netDown: "0",
+  netUp: "0",
+  storage: [],
+  containers: [],
+  gpu: null,
+  temps: { cpu: null, gpu: null, sys: null },
+  diskUsedPerc: null,
+  uptimeDays: null,
+  swap: null,
+  loadAvg: null,
+  netErrors: null,
+  disks: [],
+  smart: [],
+  power: { watts: null, kwhEstimate: null },
+  backup: { lastRun: null, lastRunAgo: null, success: null, size: null },
+  ups: { batteryPerc: null, loadPerc: null, runtimeMin: null, status: null },
+  platform: "linux",
+  agentConnected: false,
+  metricsSource: "unavailable",
+}
+
+let cachedStats: StatsData | null = null
+let cachedHistory: Partial<Record<TimeRange, HistoryPoint[]>> = {}
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -314,14 +342,22 @@ function BackupWidget() {
 
 // ── Main Section ───────────────────────────────────────────────────────────
 
-export function MetricsSection({ landingData }: { landingData?: StatsData }) {
-  const [stats, setStats] = useState<StatsData | null>(landingData || null)
-  const [history, setHistory] = useState<HistoryPoint[]>([])
+export function MetricsSection({
+  landingData,
+  scrollContainerRef,
+  showScrollCue = false,
+}: {
+  landingData?: StatsData
+  scrollContainerRef?: RefObject<HTMLDivElement | null>
+  showScrollCue?: boolean
+}) {
+  const [stats, setStats] = useState<StatsData | null>(landingData || cachedStats || null)
+  const [history, setHistory] = useState<HistoryPoint[]>(landingData ? [] : cachedHistory["1h"] || [])
   const [range, setRange] = useState<TimeRange>("1h")
   const [rangeOpen, setRangeOpen] = useState(false)
   const [cpuHistory, setCpuHistory] = useState<number[]>([])
   const [memHistory, setMemHistory] = useState<number[]>([])
-  const [loading, setLoading] = useState(!landingData)
+  const [loading, setLoading] = useState(!landingData && !cachedStats)
   const [expandedContainer, setExpandedContainer] = useState<string | null>(null)
   const isFetching = useRef(false)
   const rangeRef = useRef<HTMLDivElement>(null)
@@ -348,13 +384,14 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
         netUp: Math.random() * 0.5
       }))
       setHistory(mockHistory)
+      cachedHistory[r] = mockHistory
       return
     }
     fetch(`/api/stats/history?range=${r}`)
       .then(res => res.json())
       .then(data => {
         if (Array.isArray(data)) {
-          setHistory(data.map((d: any) => ({
+          const mappedHistory = data.map((d: any) => ({
             time: d.time,
             cpu: d.cpu ?? 0,
             memory: d.memory ?? 0,
@@ -362,7 +399,9 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
             disk: d.disk ?? 0,
             netDown: parseFloat(d.netDown) || 0,
             netUp: parseFloat(d.netUp) || 0,
-          })))
+          }))
+          setHistory(mappedHistory)
+          cachedHistory[r] = mappedHistory
           setCpuHistory(data.map((d: any) => d.cpu ?? 0).slice(-30))
           setMemHistory(data.map((d: any) => d.memory ?? 0).slice(-30))
         }
@@ -378,6 +417,7 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
       const data = await res.json()
       if (data && !data.error) {
         setStats(data)
+        cachedStats = data
         setLoading(false)
         const diskPerc = data.diskUsedPerc ?? 0
         setCpuHistory(prev => [...prev, parseFloat(data.cpu) || 0].slice(-30))
@@ -392,6 +432,15 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
           netDown: parseFloat(data.netDown) || 0,
           netUp: parseFloat(data.netUp) || 0,
         }].slice(-1344))
+        cachedHistory[range] = [...(cachedHistory[range] || []), {
+          time: now,
+          cpu: parseFloat(data.cpu) || 0,
+          memory: parseFloat(data.memPerc) || 0,
+          gpu: data?.gpu?.load ?? 0,
+          disk: diskPerc,
+          netDown: parseFloat(data.netDown) || 0,
+          netUp: parseFloat(data.netUp) || 0,
+        }].slice(-1344)
       }
     } catch { console.error("Metrics offline") }
     finally { isFetching.current = false }
@@ -401,18 +450,7 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
   useEffect(() => { fetchStats(); const i = setInterval(fetchStats, 5000); return () => clearInterval(i) }, [fetchStats])
 
   const rangeLabels: Record<TimeRange, string> = { "1h": "Past hour", "6h": "Past 6 hours", "24h": "Past 24 hours", "7d": "Past 7 days" }
-
-  // ── Render ─────────────────────────────────────────────────────────────
-
-  if (!stats) {
-    return (
-      <div className="flex flex-col h-screen overflow-hidden pl-[88px]">
-        <div className="flex items-center justify-center h-full text-foreground/20">
-          <span className="text-xs font-medium animate-pulse">Loading metrics...</span>
-        </div>
-      </div>
-    )
-  }
+  const resolvedStats = stats ?? EMPTY_STATS
 
   const chartTooltip = {
     contentStyle: { backgroundColor: "var(--card)", border: "1px solid var(--border)", borderRadius: "8px", fontSize: "11px", padding: "6px 10px", boxShadow: "0 2px 8px rgba(0,0,0,0.12)" },
@@ -435,15 +473,15 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
           </div>
           {/* Platform badge */}
           <span className={`px-2 py-0.5 rounded text-[9px] font-bold uppercase tracking-tight border ${
-            stats.platform === 'linux' ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20' :
-            stats.platform === 'darwin' ? 'bg-blue-500/10 text-blue-400 border-blue-500/20' :
-            stats.platform === 'win32' ? 'bg-indigo-500/10 text-indigo-400 border-indigo-500/20' :
+            resolvedStats.platform === 'linux' ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20' :
+            resolvedStats.platform === 'darwin' ? 'bg-blue-500/10 text-blue-400 border-blue-500/20' :
+            resolvedStats.platform === 'win32' ? 'bg-indigo-500/10 text-indigo-400 border-indigo-500/20' :
             'bg-secondary/10 text-foreground/30 border-border'
           }`}>
-            {stats.platform === 'darwin' ? 'macOS' : stats.platform === 'win32' ? 'Windows' : stats.platform}
+            {resolvedStats.platform === 'darwin' ? 'macOS' : resolvedStats.platform === 'win32' ? 'Windows' : resolvedStats.platform}
           </span>
           {/* Agent status */}
-          {stats.agentConnected && (
+          {resolvedStats.agentConnected && (
             <span className="px-2 py-0.5 rounded text-[9px] font-bold uppercase tracking-tight bg-cyan-500/10 text-cyan-400 border border-cyan-500/20" title="Host agent providing metrics">
               Agent Connected
             </span>
@@ -471,7 +509,7 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
       </div>
 
       {/* Scrollable content */}
-      <div className="flex-1 overflow-y-auto px-3 sm:px-6 py-3 space-y-4">
+      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto px-3 sm:px-6 py-3 space-y-4">
 
         {/* Stat pills */}
         <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
@@ -488,31 +526,31 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
             <div className="flex flex-wrap items-center gap-x-4 sm:gap-x-6 gap-y-2">
               <div className="flex items-baseline gap-1.5" title="Total CPU usage across all containers">
                 <span className="text-[10px] text-foreground/30 uppercase tracking-wider">CPU</span>
-                <span className="text-base font-mono font-semibold text-foreground tabular-nums">{stats?.cpu ?? "0"}%</span>
+                <span className="text-base font-mono font-semibold text-foreground tabular-nums">{resolvedStats.cpu}%</span>
                 <Sparkline data={cpuHistory} color="#0ea5e9" />
               </div>
               <span className="text-foreground/10">|</span>
               <div className="flex items-baseline gap-1.5" title="Memory usage and total GiB consumed">
                 <span className="text-[10px] text-foreground/30 uppercase tracking-wider">Memory</span>
-                <span className="text-base font-mono font-semibold text-foreground tabular-nums">{stats?.memPerc ?? "0"}%</span>
-                <span className="text-[10px] text-foreground/25">{stats?.memBytes ?? "0"} GiB</span>
+                <span className="text-base font-mono font-semibold text-foreground tabular-nums">{resolvedStats.memPerc}%</span>
+                <span className="text-[10px] text-foreground/25">{resolvedStats.memBytes} GiB</span>
                 <Sparkline data={memHistory} color="#8b5cf6" />
               </div>
               <span className="text-foreground/10">|</span>
               <div className="flex items-baseline gap-1.5" title="Root filesystem disk usage">
                 <span className="text-[10px] text-foreground/30 uppercase tracking-wider">Disk</span>
-                <span className="text-base font-mono font-semibold text-foreground tabular-nums">{stats?.diskUsedPerc ?? "—"}%</span>
+                <span className="text-base font-mono font-semibold text-foreground tabular-nums">{resolvedStats.diskUsedPerc ?? "—"}%</span>
               </div>
               <span className="text-foreground/10">|</span>
               <div className="flex items-baseline gap-1.5" title="System uptime in days since last reboot">
                 <span className="text-[10px] text-foreground/30 uppercase tracking-wider">Uptime</span>
-                <span className="text-base font-mono font-semibold text-foreground tabular-nums">{stats?.uptimeDays ?? "—"}d</span>
+                <span className="text-base font-mono font-semibold text-foreground tabular-nums">{resolvedStats.uptimeDays ?? "—"}d</span>
               </div>
               <span className="text-foreground/10">|</span>
               <div className="flex items-baseline gap-1.5" title="Network throughput — download and upload MB/s">
                 <span className="text-[10px] text-foreground/30 uppercase tracking-wider">Net</span>
-                <span className="text-[11px] font-mono text-emerald-500 tabular-nums">↓{stats?.netDown ?? "0"}</span>
-                <span className="text-[11px] font-mono text-rose-400 tabular-nums">↑{stats?.netUp ?? "0"}</span>
+                <span className="text-[11px] font-mono text-emerald-500 tabular-nums">↓{resolvedStats.netDown}</span>
+                <span className="text-[11px] font-mono text-rose-400 tabular-nums">↑{resolvedStats.netUp}</span>
                 <span className="text-[9px] text-foreground/20">MB/s</span>
               </div>
             </div>
@@ -585,22 +623,22 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
                 <div className="grid grid-cols-4 gap-3">
                   <div>
                     <div className="text-[9px] text-foreground/25 uppercase tracking-wider">Swap</div>
-                    <div className="text-sm font-mono font-semibold text-foreground tabular-nums mt-0.5">{stats.swap ? `${stats.swap.perc.toFixed(0)}%` : "—"}</div>
+                    <div className="text-sm font-mono font-semibold text-foreground tabular-nums mt-0.5">{resolvedStats.swap ? `${resolvedStats.swap.perc.toFixed(0)}%` : "—"}</div>
                   </div>
                   <div>
                     <div className="text-[9px] text-foreground/25 uppercase tracking-wider">Load</div>
-                    <div className="text-sm font-mono font-semibold text-foreground tabular-nums mt-0.5">{stats.loadAvg ? stats.loadAvg.load1.toFixed(2) : "—"}</div>
-                    {stats.loadAvg && <div className="text-[9px] text-foreground/15 tabular-nums">{stats.loadAvg.load5} · {stats.loadAvg.load15}</div>}
+                    <div className="text-sm font-mono font-semibold text-foreground tabular-nums mt-0.5">{resolvedStats.loadAvg ? resolvedStats.loadAvg.load1.toFixed(2) : "—"}</div>
+                    {resolvedStats.loadAvg && <div className="text-[9px] text-foreground/15 tabular-nums">{resolvedStats.loadAvg.load5} · {resolvedStats.loadAvg.load15}</div>}
                   </div>
                   <div>
                     <div className="text-[9px] text-foreground/25 uppercase tracking-wider">CPU Temp</div>
-                    <div className="text-sm font-mono font-semibold text-foreground tabular-nums mt-0.5">{stats.temps?.cpu ? `${stats.temps.cpu}°` : "—"}</div>
-                    {stats.gpu?.temp && <div className="text-[9px] text-foreground/15 tabular-nums">GPU {stats.gpu.temp}°</div>}
+                    <div className="text-sm font-mono font-semibold text-foreground tabular-nums mt-0.5">{resolvedStats.temps?.cpu ? `${resolvedStats.temps.cpu}°` : "—"}</div>
+                    {resolvedStats.gpu?.temp && <div className="text-[9px] text-foreground/15 tabular-nums">GPU {resolvedStats.gpu.temp}°</div>}
                   </div>
                   <div>
                     <div className="text-[9px] text-foreground/25 uppercase tracking-wider">Net Health</div>
-                    <div className="text-sm font-mono font-semibold tabular-nums mt-0.5" style={{ color: (stats.netErrors && (stats.netErrors.rxErrors + stats.netErrors.txDropped) > 0) ? "#ef4444" : "#22c55e" }}>
-                      {stats.netErrors ? (stats.netErrors.rxErrors + stats.netErrors.txErrors + stats.netErrors.rxDropped + stats.netErrors.txDropped) : "—"}
+                    <div className="text-sm font-mono font-semibold tabular-nums mt-0.5" style={{ color: (resolvedStats.netErrors && (resolvedStats.netErrors.rxErrors + resolvedStats.netErrors.txDropped) > 0) ? "#ef4444" : "#22c55e" }}>
+                      {resolvedStats.netErrors ? (resolvedStats.netErrors.rxErrors + resolvedStats.netErrors.txErrors + resolvedStats.netErrors.rxDropped + resolvedStats.netErrors.txDropped) : "—"}
                     </div>
                   </div>
                 </div>
@@ -618,8 +656,8 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
               <SectionHeader title="Storage" />
               <div className="bg-secondary/5 rounded-lg p-3">
                 <div className="space-y-2">
-                  {stats.storage.map((s, i) => {
-                    const total = stats.storage.reduce((sum, x) => sum + x.bytes, 0)
+                  {resolvedStats.storage.map((s, i) => {
+                    const total = resolvedStats.storage.reduce((sum, x) => sum + x.bytes, 0)
                     const pct = total > 0 ? ((s.bytes / total) * 100).toFixed(1) : "0"
                     const colors = ["#0ea5e9", "#8b5cf6", "#f59e0b", "#22c55e", "#ec4899", "#06b6d4"]
                     return (
@@ -634,13 +672,13 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
                       </div>
                     )
                   })}
-                  {stats.storage.length === 0 && <div className="text-[11px] text-foreground/20 py-4">No storage data</div>}
+                  {resolvedStats.storage.length === 0 && <div className="text-[11px] text-foreground/20 py-4">{loading ? "Loading storage..." : "No storage data"}</div>}
                 </div>
               </div>
             </div>
 
             {/* Disk Usage */}
-            {stats.disks && stats.disks.length > 0 && (
+            {resolvedStats.disks && resolvedStats.disks.length > 0 && (
               <div>
                 <SectionHeader title="Disk Usage" />
                 <div className="bg-secondary/5 rounded-lg overflow-hidden">
@@ -653,7 +691,7 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
                       </tr>
                     </thead>
                     <tbody>
-                      {stats.disks.map((d, i) => (
+                      {resolvedStats.disks.map((d, i) => (
                         <tr key={i} className="border-b border-border/40 hover:bg-secondary/5 transition-colors">
                           <td className="py-1.5 px-2 text-foreground/50 truncate max-w-[120px]" title={d.mount}>{d.mount}</td>
                           <td className="py-1.5 px-2 text-right font-mono tabular-nums text-foreground/40">{d.used}/{d.total}</td>
@@ -667,28 +705,28 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
             )}
 
             {/* UPS Status */}
-            {stats?.ups && stats.ups.batteryPerc !== null && (
+            {resolvedStats.ups && resolvedStats.ups.batteryPerc !== null && (
               <div>
                 <SectionHeader title="UPS" />
                 <div className="bg-secondary/5 rounded-lg p-3">
                   <div className="grid grid-cols-3 gap-4">
                     <div>
                       <div className="text-[9px] text-foreground/25 uppercase tracking-wider">Battery</div>
-                      <div className="text-base font-mono font-semibold text-foreground tabular-nums mt-0.5">{stats.ups.batteryPerc}%</div>
+                      <div className="text-base font-mono font-semibold text-foreground tabular-nums mt-0.5">{resolvedStats.ups.batteryPerc}%</div>
                     </div>
                     <div>
                       <div className="text-[9px] text-foreground/25 uppercase tracking-wider">Load</div>
-                      <div className="text-base font-mono font-semibold text-foreground tabular-nums mt-0.5">{stats.ups.loadPerc ? `${stats.ups.loadPerc}%` : "—"}</div>
+                      <div className="text-base font-mono font-semibold text-foreground tabular-nums mt-0.5">{resolvedStats.ups.loadPerc ? `${resolvedStats.ups.loadPerc}%` : "—"}</div>
                     </div>
                     <div>
                       <div className="text-[9px] text-foreground/25 uppercase tracking-wider">Runtime</div>
-                      <div className="text-base font-mono font-semibold text-foreground tabular-nums mt-0.5">{stats.ups.runtimeMin ? `${stats.ups.runtimeMin.toFixed(0)}m` : "—"}</div>
+                      <div className="text-base font-mono font-semibold text-foreground tabular-nums mt-0.5">{resolvedStats.ups.runtimeMin ? `${resolvedStats.ups.runtimeMin.toFixed(0)}m` : "—"}</div>
                     </div>
                   </div>
-                  {stats.ups.status && (
+                  {resolvedStats.ups.status && (
                     <div className="mt-1">
-                      <span className="text-[9px] font-medium" style={{ color: stats.ups.status === 'OL' ? '#22c55e' : '#f59e0b' }}>
-                        {stats.ups.status === 'OL' ? 'Online' : stats.ups.status}
+                      <span className="text-[9px] font-medium" style={{ color: resolvedStats.ups.status === 'OL' ? '#22c55e' : '#f59e0b' }}>
+                        {resolvedStats.ups.status === 'OL' ? 'Online' : resolvedStats.ups.status}
                       </span>
                     </div>
                   )}
@@ -699,7 +737,7 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
         </div>
         {/* Containers table */}
         <div>
-          <SectionHeader title={`Containers (${stats.containers.length})`} />
+          <SectionHeader title={`Containers (${resolvedStats.containers.length})`} />
           <div className="overflow-x-auto -mx-1">
             <table className="w-full text-[11px]">
               <thead>
@@ -713,7 +751,7 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
                 </tr>
               </thead>
               <tbody>
-                {stats.containers.length > 0 ? stats.containers.map(c => (
+                {resolvedStats.containers.length > 0 ? resolvedStats.containers.map(c => (
                   <>
                     <tr
                       key={c.name}
@@ -767,6 +805,15 @@ export function MetricsSection({ landingData }: { landingData?: StatsData }) {
             </table>
           </div>
         </div>
+
+        {showScrollCue && (
+          <div className="flex justify-center mt-20 pb-4">
+            <div className="flex flex-col items-center gap-2 opacity-30 text-foreground">
+              <span className="text-xs uppercase tracking-wider">Scroll for backups</span>
+              <div className="w-px h-8 bg-gradient-to-b from-current to-transparent animate-pulse" />
+            </div>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/Project_S_Logs/61_Home_Scroll_Snap_Refinement.md
+++ b/Project_S_Logs/61_Home_Scroll_Snap_Refinement.md
@@ -3,7 +3,7 @@
 **Date:** April 18, 2026
 **Author:** Basil Suhail
 **Related Issue:** #272
-**PR:** TBD
+**PR:** #273
 **Status:** Ready for review
 
 ---

--- a/Project_S_Logs/61_Home_Scroll_Snap_Refinement.md
+++ b/Project_S_Logs/61_Home_Scroll_Snap_Refinement.md
@@ -1,9 +1,9 @@
 # 61 — Home Scroll Snap Refinement
 
-**Date:** April 18, 2026  
-**Author:** Basil Suhail  
-**Related Issue:** #272  
-**PR:** TBD  
+**Date:** April 18, 2026
+**Author:** Basil Suhail
+**Related Issue:** #272
+**PR:** TBD
 **Status:** Ready for review
 
 ---

--- a/Project_S_Logs/61_Home_Scroll_Snap_Refinement.md
+++ b/Project_S_Logs/61_Home_Scroll_Snap_Refinement.md
@@ -1,0 +1,58 @@
+# 61 — Home Scroll Snap Refinement
+
+**Date:** April 18, 2026  
+**Author:** Basil Suhail  
+**Related Issue:** #272  
+**PR:** TBD  
+**Status:** Ready for review
+
+---
+
+## Context
+
+The dashboard home page now includes an embedded vertical journey:
+
+- Home
+- Metrics
+- Backups
+
+That flow needed to feel like three separate full-screen pages while still preserving native inner scrolling inside the embedded Metrics and Backups views. The original implementation could skip past Metrics under wheel momentum, leak scroll gestures across section boundaries, and show a loading takeover that made the Metrics embed feel unstable.
+
+## What Changed
+
+### 1. Stronger Section Snap Control
+
+- Reworked the home page wheel handling to treat Home, Metrics, and Backups as discrete snap sections.
+- Added boundary-aware transitions so inner scroll regions consume scroll normally until their top or bottom edge is reached.
+- Tightened section handoff so a fresh wheel gesture is required before moving from one full-page section to the next, reducing accidental skips caused by aggressive mouse-wheel momentum.
+
+### 2. Embedded Metrics / Backups Scroll Handoff
+
+- Passed the embedded scroll containers for Metrics and Backups back up to the home controller.
+- Prevented the home page from programmatically driving the inner panels, which was causing visible “self-scrolling” glitches.
+- Preserved the standalone dock-opened app pages as independent non-embedded experiences.
+
+### 3. Metrics Loading UX
+
+- Removed the full-screen “Loading metrics...” takeover from the embedded Metrics experience.
+- Kept the page shell mounted with inline loading states and cached metrics/history when available so the transition feels stable while data refreshes.
+
+### 4. Embedded Scroll Cue
+
+- Added a `Scroll for backups` indicator to the embedded Metrics section.
+- Scoped that cue to the home scroll flow only, so the standalone Metrics page opened from the dock does not show it.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `Dashboard/Dashboard1/app/page.tsx` | Reworked home snap behavior, section transition gating, and embedded scroll orchestration. |
+| `Dashboard/Dashboard1/components/dashboard/metrics-section.tsx` | Added embedded scroll cue support and replaced the blocking loading takeover with inline loading behavior. |
+| `Dashboard/Dashboard1/components/dashboard/backup-section.tsx` | Exposed the embedded backups scroll container to the home page controller. |
+
+## Result
+
+- Home, Metrics, and Backups now behave like distinct pages in the home flow.
+- Metrics no longer gets skipped as easily during mouse-wheel scrolling.
+- Embedded Metrics and Backups continue to scroll internally without breaking the page snap model.
+- The dock-opened standalone app pages remain clean and separate from the embedded home experience.


### PR DESCRIPTION
## Summary
- refine the home scroll journey so Home, Metrics, and Backups behave like distinct snapped pages
- preserve native inner scrolling inside the embedded Metrics and Backups panels
- replace the embedded Metrics loading takeover with inline loading behavior and cached data
- add the embedded-only "Scroll for backups" cue while keeping the dock-opened Metrics page clean
- add project log 61 for the scroll snap refinement work

Closes #272

## Test plan
- [x] Reviewed branch diff and staged only the dashboard/log files for this change
- [x] Ran `git diff --check origin/main...HEAD`
- [x] Rebuilt via `./boom.sh` and confirmed the updated dashboard behavior in the branch
- [ ] Ran `npm run build` in `Dashboard/Dashboard1` (blocked by existing repo issues: missing `bs58` resolution and external Google Fonts fetch in restricted network)
