### PR TITLE
fix(boom): preserve explicit HOMEFORGE_LAN_IP, no auto-overwrite

### DIFF
--- a/Project_S_Logs/62_Collabora_frame-ancestors_localhost_Incident.md
+++ b/Project_S_Logs/62_Collabora_frame-ancestors_localhost_Incident.md
@@ -105,3 +105,24 @@ docker compose up -d nextcloud collabora
 | `docker-compose.yml` | `server_name` now uses `${HOMEFORGE_LAN_IP:-localhost}:9980` |
 | `config/nextcloud/setup-office.sh` | Curl-fetches discovery XML on every start; adds `chown www-data`; does NOT call `richdocuments:activate-config` |
 | `.env` | `HOMEFORGE_LAN_IP=localhost` |
+| `boom.sh` | Auto-detect no longer overwrites explicit `localhost` — only runs when `HOMEFORGE_LAN_IP` is blank |
+
+---
+
+## 8. Follow-up Fix: boom.sh Auto-detect Overwriting localhost
+
+**Date:** 2026-04-19 (same session)
+
+**Problem:** `boom.sh` lines 67–85 ran auto-detect whenever `HOMEFORGE_LAN_IP=localhost`, overwriting the user's explicit value with the machine's detected LAN IP on every run. This silently re-introduced the `frame-ancestors` mismatch even after the user had correctly set `localhost`.
+
+**Old condition (broken):**
+```bash
+if [ -z "$CURRENT_LAN_IP" ] || [ "$CURRENT_LAN_IP" = "localhost" ]; then
+```
+
+**New condition (fixed):**
+```bash
+if [ -z "$CURRENT_LAN_IP" ]; then
+```
+
+**Rule:** `boom.sh` auto-detection runs ONLY when `HOMEFORGE_LAN_IP` is completely empty/unset. Any explicit value — `localhost` or a real IP — is preserved as-is. If you want LAN access from other devices, set the IP manually in `.env`.

--- a/boom.sh
+++ b/boom.sh
@@ -64,9 +64,20 @@ if [ ! -f .env ]; then
     fi
 fi
 
-# Auto-detect LAN IP
+# Auto-detect LAN IP — first run only.
+#
+# When to use localhost vs a real LAN IP:
+#   localhost  — accessing HomeForge ONLY from the machine running Docker
+#                (browser and Docker on same host). This is the safe default.
+#   LAN IP     — accessing from OTHER devices on your network (phone, laptop, etc.)
+#                Set HOMEFORGE_LAN_IP manually in .env to your machine's LAN IP.
+#
+# Auto-detection runs ONLY when .env has no IP (empty or unset).
+# If you explicitly set HOMEFORGE_LAN_IP=localhost, boom.sh will NEVER overwrite it.
+# If you explicitly set a real LAN IP, boom.sh will NEVER overwrite it either.
+# Only a blank/missing value triggers auto-detection.
 CURRENT_LAN_IP=$(grep "^HOMEFORGE_LAN_IP=" .env 2>/dev/null | cut -d'=' -f2-)
-if [ -z "$CURRENT_LAN_IP" ] || [ "$CURRENT_LAN_IP" = "localhost" ]; then
+if [ -z "$CURRENT_LAN_IP" ]; then
     DETECTED_IP=""
     if [[ "$OSTYPE" == "darwin"* ]]; then
         DETECTED_IP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null || true)


### PR DESCRIPTION
Auto-detection now only runs when HOMEFORGE_LAN_IP is blank. Explicit localhost or LAN IP in .env is never overwritten. Added comments explaining localhost vs LAN IP decision.